### PR TITLE
feat: funding module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,8 +7,5 @@ out/
 /broadcast/*/31337/
 /broadcast/**/dry-run/
 
-# Docs
-docs/
-
 # Dotenv file
 .env

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "lib/uniswap-v2-core"]
 	path = lib/uniswap-v2-core
 	url = https://github.com/Uniswap/v2-core
+[submodule "lib/hooks-trampoline"]
+	path = lib/hooks-trampoline
+	url = https://github.com/cowprotocol/hooks-trampoline

--- a/docs/funding-module.md
+++ b/docs/funding-module.md
@@ -1,0 +1,58 @@
+# FundingModule
+
+## Requirements
+
+- The module is configured on a Safe that **never** retains any funds
+- The limit price of the AMM (destination) is to remain unaffected by the funding
+- Allowances given to the staging Safe are protected by limiting the output of each `pull` to a maximum of `sellAmount`
+
+### Safe never retains funds
+
+Configuring the module on a Safe that retains funds would increase the attack surface. In this method, the Safe is only used as a staging area for the funds, and the value at risk is contained to the approvals that are set on the funding source for the staging Safe.
+
+### Limit price remains unaffected
+
+The limit price of the AMM (funding destination) is to remain unaffected by the funding. This is achieved by calculating the amount of `sellToken` that is required to be transferred to the AMM (funding destination) to preserve the limit price given the amount of `buyToken` that was bought by the staging Safe.
+
+As the amount of `buyToken` that was bought is required to be known, and the staging Safe is only _selling_ (ie. the output/bought amount isn't visible in a CoW Protocol batch), the `buyToken` amount is sent to the staging safe (and simply the balance of the staging Safe is used).
+
+### Allowance protection
+
+The staging Safe may only at any time contain a maximum of `sellAmount` of `sellToken` (assuming the `pull()` was called out-of-auction). Then, subsequent invocations within the batch auction will simply `return`, as the staging Safe knows that it needn't do anything. This therefore prevents malicious actors draining the entire allowance of the funding source to the staging Safe, and therefore causing reverts in the `push()` function when the matching `sellToken` is transferred to the AMM (funding destination).
+
+## Methodology
+
+1. The source of funds can be any arbitrary address that holds the funding `sellToken`
+2. A staging Safe is configured with the module enabled
+3. The address from (1) sets an allowance for the staging Safe to transfer `sellToken` on its behalf
+4. The staging Safe handles the selling of `sellToken` for `buyToken` using CoW Protocol's TWAP
+5. The staging Safe calculates the amount of `sellToken` given the amount of `buyToken` bought to preserve the AMM's limit price
+6. The staging Safe transfers the `buyToken` to the AMM (funding destination)
+7. The staging Safe transfers the `sellToken` directly from (1) to the AMM (funding destination) to satisfy (5)
+
+## Sequence diagram
+
+```mermaid
+sequenceDiagram
+    participant Batch Auction
+    participant Staging
+    actor Source
+    actor Destination
+    Batch Auction->>+Staging: Pre-hook pull()
+    Staging->>+Source: transfer sellToken to staging
+    Source-->>-Staging: transfer sellToken
+    Staging-->>-Batch Auction: return
+    Batch Auction->>Batch Auction: Swap sellToken for buyToken
+    Batch Auction->>+Staging: Post-hook push()
+    Staging->>+Destination: fetch buyToken balance
+    Destination-->>-Staging: buyToken balance
+    Staging->>Staging: Check amount of buyToken bought
+    Staging->>Staging: Calculate required matching sellToken amount
+    Staging->>+Destination: transfer bought buyTokens
+    Destination-->>-Staging: return
+    Staging->>+Source: transfer matching sellTokens
+    Source->>+Destination: transfer sellToken
+    Destination-->>-Source: return
+    Source-->>-Staging: return
+    Staging-->>-Batch Auction: return
+```

--- a/src/FundingModule.sol
+++ b/src/FundingModule.sol
@@ -15,8 +15,6 @@ import {SafeModuleSafeERC20} from "./vendored/libraries/SafeModuleSafeERC20.sol"
 contract FundingModule {
     using SafeCast for uint256;
 
-    address private constant HOOKS_TRAMPOLINE = 0x01DcB88678aedD0C4cC9552B20F4718550250574;
-
     IERC20 public immutable sellToken;
     IERC20 public immutable buyToken;
     ISafe public immutable stagingSafe;
@@ -24,11 +22,6 @@ contract FundingModule {
     address public immutable fundingDst;
 
     uint256 public immutable sellAmount;
-
-    modifier onlyTrampoline() {
-        require(msg.sender == HOOKS_TRAMPOLINE, "FundingModule: caller is not the trampoline");
-        _;
-    }
 
     constructor(
         IERC20 _sellToken,
@@ -53,7 +46,7 @@ contract FundingModule {
      * @dev No guarding against multiple calls from multiple batches, as worst case, all allowed
      *      funds are pulled from the `fundingSrc` to the staging safe (where they would remain).
      */
-    function pull() external onlyTrampoline {
+    function pull() external {
         SafeModuleSafeERC20.safeTransferFrom(
             stagingSafe, // safe that has this module enabled
             sellToken, // token being transferred from
@@ -69,7 +62,7 @@ contract FundingModule {
      * @dev If this hook fails to be included in a settlement due to a malicious solver, the
      *      next discrete order will be able to include the requisite amounts.
      */
-    function push() external onlyTrampoline {
+    function push() external {
         uint256 boughtAmount = buyToken.balanceOf(address(stagingSafe));
 
         uint112 x = buyToken.balanceOf(fundingDst).toUint112();

--- a/src/FundingModule.sol
+++ b/src/FundingModule.sol
@@ -81,7 +81,7 @@ contract FundingModule {
         }
 
         // Transfer bought tokens to fundingDst
-        SafeModuleSafeERC20.safeTransferFrom(stagingSafe, buyToken, address(stagingSafe), fundingDst, boughtAmount);
+        SafeModuleSafeERC20.safeTransfer(stagingSafe, buyToken, fundingDst, deltaY);
 
         // Transfer matching amount of `sellToken` to `fundingDst`. This would allow for
         // `sellToken` to be drained from the funding safe, however only if a "malicious"

--- a/src/FundingModule.sol
+++ b/src/FundingModule.sol
@@ -1,0 +1,99 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.0 <0.9.0;
+
+import {IERC20} from "lib/composable-cow/lib/@openzeppelin/contracts/interfaces/IERC20.sol";
+import {SafeCast} from "lib/composable-cow/lib/@openzeppelin/contracts/utils/math/SafeCast.sol";
+import {ISafe} from "./vendored/interfaces/ISafe.sol";
+import {SafeModuleSafeERC20} from "./vendored/libraries/SafeModuleSafeERC20.sol";
+
+/**
+ * @title CoW AMM Funding Module
+ * @author CoW Protocol Developers
+ * @dev A privileged module that allows using Hooks in combination with TWAP to fund CoW AMMs.
+ *      **NOTE**: Any hook that fails to execute will *NOT* cause the entire settlement to fail.
+ */
+contract FundingModule {
+    using SafeCast for uint256;
+
+    address private constant HOOKS_TRAMPOLINE = 0x01DcB88678aedD0C4cC9552B20F4718550250574;
+
+    IERC20 public immutable sellToken;
+    IERC20 public immutable buyToken;
+    ISafe public immutable stagingSafe;
+    address public immutable fundingSrc;
+    address public immutable fundingDst;
+
+    uint256 public immutable sellAmount;
+
+    modifier onlyTrampoline() {
+        require(msg.sender == HOOKS_TRAMPOLINE, "FundingModule: caller is not the trampoline");
+        _;
+    }
+
+    constructor(
+        IERC20 _sellToken,
+        IERC20 _buyToken,
+        ISafe _stagingSafe,
+        address _fundingSrc,
+        address _fundingDst,
+        uint256 _sellAmount
+    ) {
+        require(_sellToken != _buyToken, "FundingModule: sellToken and buyToken must be different");
+        sellToken = _sellToken;
+        buyToken = _buyToken;
+        stagingSafe = _stagingSafe;
+        fundingSrc = _fundingSrc;
+        fundingDst = _fundingDst;
+        sellAmount = _sellAmount;
+    }
+
+    /**
+     * @notice Pulls the `sellToken` from the `fundingSrc` to the staging safe.
+     * @dev Requires calling from the trampoline to ensure the call is part of a settlement
+     * @dev No guarding against multiple calls from multiple batches, as worst case, all allowed
+     *      funds are pulled from the `fundingSrc` to the staging safe (where they would remain).
+     */
+    function pull() external onlyTrampoline {
+        SafeModuleSafeERC20.safeTransferFrom(
+            stagingSafe, // safe that has this module enabled
+            sellToken, // token being transferred from
+            fundingSrc, // address to transfer from
+            address(stagingSafe), // address to transfer to
+            sellAmount // amount to transfer
+        );
+    }
+
+    /**
+     * @notice Push bought tokens, and a corresponding amount of `sellToken`s to `fundingDst`.
+     * @dev Requires calling from the trampoline to ensure the call is part of a settlement
+     * @dev If this hook fails to be included in a settlement due to a malicious solver, the
+     *      next discrete order will be able to include the requisite amounts.
+     */
+    function push() external onlyTrampoline {
+        uint256 boughtAmount = buyToken.balanceOf(address(stagingSafe));
+
+        uint112 x = buyToken.balanceOf(fundingDst).toUint112();
+        uint112 y = sellToken.balanceOf(fundingDst).toUint112();
+
+        // x * y has a maximum value of 2^224, which is less than 2^256-1, so this is safe
+        // If x + boughtAmount is greater than 2^224 (`boughtAmount` may be 2^256 - 1), the
+        // denominator will be greater than the numerator resulting in
+        // `requiredSelltokenReserves` = 0. This has implications for underflow protection
+        // on `topUpSellTokenAmount`, which is why `topUpSellTokenAmount` is checked but
+        // `requiredSellTokenReserves` is not.
+        uint256 requiredSellTokenReserves;
+        unchecked {
+            requiredSellTokenReserves = x * y / (x + boughtAmount);
+        }
+
+        uint256 topUpSellTokenAmount = requiredSellTokenReserves - y;
+
+        // Transfer bought tokens to fundingDst
+        SafeModuleSafeERC20.safeTransferFrom(stagingSafe, buyToken, address(stagingSafe), fundingDst, boughtAmount);
+
+        // Transfer matching amount of sellToken to fundingDst
+        SafeModuleSafeERC20.safeTransferFrom(
+            stagingSafe, sellToken, address(fundingSrc), fundingDst, topUpSellTokenAmount
+        );
+    }
+}

--- a/src/vendored/interfaces/ISafe.sol
+++ b/src/vendored/interfaces/ISafe.sol
@@ -12,7 +12,7 @@ import {Enum} from "safe/contracts/common/Enum.sol";
 
 /**
  * @notice Modules are extensions with unlimited access to a Safe that can be added to a Safe by its owners.
- *            ⚠️ WARNING: Modules are a security risk since they can execute arbitrary transactions, 
+ *            ⚠️ WARNING: Modules are a security risk since they can execute arbitrary transactions,
  *            so only trusted and audited modules should be added to a Safe. A malicious module can
  *            completely takeover a Safe.
  * @author @safe-global/safe-protocol

--- a/src/vendored/interfaces/ISafe.sol
+++ b/src/vendored/interfaces/ISafe.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+
+// Vendored from Safe Global contracts with minor modifications:
+// - Removed all functions except `execTransactionFromModuleReturnData`
+// - Used naming convention for interface of `ISafe`
+// - Minor edits to dev comments removing title
+// <https://github.com/safe-global/safe-smart-account/blob/914d0f8fab0e8f73ef79581f6fbce86e34b049c3/contracts/interfaces/IModuleManager.sol>
+
+pragma solidity >=0.7.0 <0.9.0;
+
+import {Enum} from "safe/contracts/common/Enum.sol";
+
+/**
+ * @notice Modules are extensions with unlimited access to a Safe that can be added to a Safe by its owners.
+ *            ⚠️ WARNING: Modules are a security risk since they can execute arbitrary transactions, 
+ *            so only trusted and audited modules should be added to a Safe. A malicious module can
+ *            completely takeover a Safe.
+ * @author @safe-global/safe-protocol
+ */
+interface ISafe {
+    /**
+     * @notice Execute `operation` (0: Call, 1: DelegateCall) to `to` with `value` (Native Token) and return data
+     * @param to Destination address of module transaction.
+     * @param value Ether value of module transaction.
+     * @param data Data payload of module transaction.
+     * @param operation Operation type of module transaction.
+     * @return success Boolean flag indicating if the call succeeded.
+     * @return returnData Data returned by the call.
+     */
+    function execTransactionFromModuleReturnData(address to, uint256 value, bytes memory data, Enum.Operation operation)
+        external
+        returns (bool success, bytes memory returnData);
+}

--- a/src/vendored/libraries/SafeModuleAddress.sol
+++ b/src/vendored/libraries/SafeModuleAddress.sol
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MIT
+
+// Vendored from OpenZeppelin contracts with minor modifications:
+// - Removed all functions except `functionCall` and `functionCallWithValue`
+// - Functions modified to accept a `ISafe` as the first argument which
+//   is the Safe used to execute the transaction.
+// - Modified `functionCallWithValue` to execute the transaction via a Safe,
+//   designed to be called from a module.
+// - Added imports for Safe related contracts.
+// - Added import for canonical Address library.
+// <https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.0.1/contracts/utils/Address.sol>
+
+// OpenZeppelin Contracts (last updated v5.0.0) (utils/Address.sol)
+
+pragma solidity ^0.8.20;
+
+import {ISafe, Enum} from "../interfaces/ISafe.sol";
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library SafeModuleAddress {
+    /**
+     * @dev The ETH balance of the account is not enough to perform the operation.
+     */
+    error AddressInsufficientBalance(address account);
+
+    /**
+     * @dev There's no code at `target` (it is not a contract).
+     */
+    error AddressEmptyCode(address target);
+
+    /**
+     * @dev A call to an address target failed. The target may have reverted.
+     */
+    error FailedInnerCall();
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain `call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason or custom error, it is bubbled
+     * up by this function (like regular Solidity function calls). However, if
+     * the call reverted with no returned reason, this function reverts with a
+     * {FailedInnerCall} error.
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     */
+    function functionCall(ISafe safe, address target, bytes memory data) internal returns (bytes memory) {
+        return functionCallWithValue(safe, target, data, 0);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     */
+    function functionCallWithValue(ISafe safe, address target, bytes memory data, uint256 value)
+        internal
+        returns (bytes memory)
+    {
+        if (address(safe).balance < value) {
+            revert AddressInsufficientBalance(address(safe));
+        }
+        (bool success, bytes memory returndata) =
+            safe.execTransactionFromModuleReturnData(target, value, data, Enum.Operation.Call);
+        return verifyCallResultFromTarget(target, success, returndata);
+    }
+
+    /**
+     * @dev Tool to verify that a low level call to smart-contract was successful, and reverts if the target
+     * was not a contract or bubbling up the revert reason (falling back to {FailedInnerCall}) in case of an
+     * unsuccessful call.
+     */
+    function verifyCallResultFromTarget(address target, bool success, bytes memory returndata)
+        internal
+        view
+        returns (bytes memory)
+    {
+        if (!success) {
+            _revert(returndata);
+        } else {
+            // only check if target is a contract if the call was successful and the return data is empty
+            // otherwise we already know that it was a contract
+            if (returndata.length == 0 && target.code.length == 0) {
+                revert AddressEmptyCode(target);
+            }
+            return returndata;
+        }
+    }
+
+    /**
+     * @dev Reverts with returndata if present. Otherwise reverts with {FailedInnerCall}.
+     */
+    function _revert(bytes memory returndata) private pure {
+        // Look for revert reason and bubble it up if present
+        if (returndata.length > 0) {
+            // The easiest way to bubble the revert reason is using memory via assembly
+            /// @solidity memory-safe-assembly
+            assembly {
+                let returndata_size := mload(returndata)
+                revert(add(32, returndata), returndata_size)
+            }
+        } else {
+            revert FailedInnerCall();
+        }
+    }
+}

--- a/src/vendored/libraries/SafeModuleSafeERC20.sol
+++ b/src/vendored/libraries/SafeModuleSafeERC20.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+
+// Vendored from OpenZeppelin contracts with minor modifications:
+// - Removed all functions except `safeTransferFrom` and `_callOptionalReturn`
+// - Functions modified to accept an `ISafe` and `IERC20` as the first two arguments
+//   which is the Safe used to execute the transaction and the token being transferred.
+//   For executing the transaction, uses the `functionCall` function from SafeModuleAddress.sol.
+// - Added imports for Safe related contracts.
+// - Minor edits to dev comments removing `SafeERC20` references.
+// <https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.0.1/contracts/token/ERC20/utils/SafeERC20.sol>
+
+// OpenZeppelin Contracts (last updated v5.0.0) (token/ERC20/utils/SafeERC20.sol)
+
+pragma solidity ^0.8.20;
+
+import {IERC20} from "lib/composable-cow/lib/@openzeppelin/contracts/interfaces/IERC20.sol";
+import {SafeModuleAddress} from "./SafeModuleAddress.sol";
+import {ISafe, Enum} from "../interfaces/ISafe.sol";
+
+/**
+ * @title SafeModuleSafeERC20
+ * @dev Wrappers around ERC20 operations that throw on failure (when the token
+ * contract returns false). Tokens that return no value (and instead revert or
+ * throw on failure) are also supported, non-reverting calls are assumed to be
+ * successful.
+ */
+library SafeModuleSafeERC20 {
+    /**
+     * @dev An operation with an ERC20 token failed.
+     */
+    error SafeERC20FailedOperation(address token);
+
+    /**
+     * @dev Transfer `value` amount of `token` from `from` to `to`, spending the approval given by `from` to the
+     * calling contract. If `token` returns no value, non-reverting calls are assumed to be successful.
+     */
+    function safeTransferFrom(ISafe safe, IERC20 token, address from, address to, uint256 value) internal {
+        _callOptionalReturn(safe, token, abi.encodeCall(token.transferFrom, (from, to, value)));
+    }
+
+    /**
+     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement
+     * on the return value: the return value is optional (but if data is returned, it must not be false).
+     * @param token The token targeted by the call.
+     * @param data The call data (encoded using abi.encode or one of its variants).
+     */
+    function _callOptionalReturn(ISafe safe, IERC20 token, bytes memory data) private {
+        // We need to perform a low level call here, to bypass Solidity's return data size checking mechanism, since
+        // we're implementing it ourselves. We use {SafeModuleAddress-functionCall} to perform this call, which verifies that
+        // the target address contains contract code and also asserts for success in the low-level call.
+
+        bytes memory returndata = SafeModuleAddress.functionCall(safe, address(token), data);
+        if (returndata.length != 0 && !abi.decode(returndata, (bool))) {
+            revert SafeERC20FailedOperation(address(token));
+        }
+    }
+}

--- a/src/vendored/libraries/SafeModuleSafeERC20.sol
+++ b/src/vendored/libraries/SafeModuleSafeERC20.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 
 // Vendored from OpenZeppelin contracts with minor modifications:
-// - Removed all functions except `safeTransferFrom` and `_callOptionalReturn`
+// - Removed all functions except `safeTransfer`, `safeTransferFrom` and `_callOptionalReturn`
 // - Functions modified to accept an `ISafe` and `IERC20` as the first two arguments
 //   which is the Safe used to execute the transaction and the token being transferred.
 //   For executing the transaction, uses the `functionCall` function from SafeModuleAddress.sol.
@@ -29,6 +29,14 @@ library SafeModuleSafeERC20 {
      * @dev An operation with an ERC20 token failed.
      */
     error SafeERC20FailedOperation(address token);
+
+    /**
+     * @dev Transfer `value` amount of `token` from the calling contract to `to`. If `token` returns no value,
+     * non-reverting calls are assumed to be successful.
+     */
+    function safeTransfer(ISafe safe, IERC20 token, address to, uint256 value) internal {
+        _callOptionalReturn(safe, token, abi.encodeCall(token.transfer, (to, value)));
+    }
 
     /**
      * @dev Transfer `value` amount of `token` from `from` to `to`, spending the approval given by `from` to the

--- a/test/FundingModule.t.sol
+++ b/test/FundingModule.t.sol
@@ -1,6 +1,69 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.0 <0.9.0;
 
-import {FundingModuleTestHarness, IERC20, ISafe} from "./FundingModule/FundingModuleTestHarness.sol";
+import "./FundingModule/FundingModuleTestHarness.sol";
+import "lib/composable-cow/src/types/twap/TWAP.sol";
 
-contract FundingModuleTestE2E is FundingModuleTestHarness {}
+contract FundingModuleTestE2E is FundingModuleTestHarness {
+    function setUp() public virtual override(FundingModuleTestHarness) {
+        super.setUp();
+        setUpTokenAmounts();
+    }
+
+    function testFundingModuleE2E() public {
+        setUpComposableCow();
+        setUpTrampoline();
+
+        // 1. Fund the source safe with the funding amount
+        setUpTokenAmounts();
+
+        // 2. Fund the destination safe with some AMM tokens (initial)
+        setUpAmmReserves();
+
+        // 3. Ensure that the staging safe has allowance on the source safe
+        //    NOTE: This is already handled in `super.setUp()`
+
+        // 4. Create the TWAP on the staging safe
+        TWAPOrder.Data memory twapData = getTWAPOrder();
+        uint256 startTime = block.timestamp + 1 minutes;
+        vm.warp(startTime);
+        IConditionalOrder.ConditionalOrderParams memory params =
+            super.createOrder(twap, keccak256("twap"), abi.encode(twapData));
+        _createWithContext(address(stagingSafe), params, currentBlockTimestampFactory, bytes(""), false);
+
+        // 5. Make sure the vault relayer has sufficient allowance on the staging safe
+        vm.prank(address(stagingSafe));
+        token0.approve(address(relayer), twapData.n * twapData.partSellAmount);
+
+        // 6. Setup the hooks
+        HooksTrampoline.Hook[] memory preHooks = new HooksTrampoline.Hook[](1);
+        preHooks[0] = HooksTrampoline.Hook({
+            target: address(fundingModule),
+            callData: abi.encodeWithSelector(FundingModule.pull.selector),
+            gasLimit: 50000
+        });
+        HooksTrampoline.Hook[] memory postHooks = new HooksTrampoline.Hook[](1);
+        postHooks[0] = HooksTrampoline.Hook({
+            target: address(fundingModule),
+            callData: abi.encodeWithSelector(FundingModule.push.selector),
+            gasLimit: 40000
+        });
+
+        // 7. Iterate over each part of the TWAP and settle it
+        for (uint256 i = 0; i < twapData.n; i++) {
+            vm.warp(startTime + (i * twapData.t));
+
+            // 7.2. Get the order and signature for the current part of the TWAP
+            (GPv2Order.Data memory order, bytes memory signature) =
+                composableCow.getTradeableOrderWithSignature(address(stagingSafe), params, bytes(""), new bytes32[](0));
+
+            // 7.3. Settle the current part of the TWAP
+            settleWithHooks(address(stagingSafe), bob, order, signature, bytes4(0), preHooks, postHooks);
+        }
+
+        // Checks
+        assertEq(token0.balanceOf(address(fundingSrc)), FUNDING_AMOUNT - (twapData.n * twapData.partSellAmount));
+        assertEq(token0.balanceOf(address(stagingSafe)), 0);
+        assertEq(token1.balanceOf(address(stagingSafe)), 0);
+    }
+}

--- a/test/FundingModule.t.sol
+++ b/test/FundingModule.t.sol
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.0 <0.9.0;
+
+import {FundingModuleTestHarness, IERC20, ISafe} from "./FundingModule/FundingModuleTestHarness.sol";
+
+contract FundingModuleTestE2E is FundingModuleTestHarness {}

--- a/test/FundingModule/FundingModuleTestHarness.sol
+++ b/test/FundingModule/FundingModuleTestHarness.sol
@@ -1,10 +1,22 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.0 <0.9.0;
 
-import {Base} from "lib/composable-cow/test/Base.t.sol";
+import "lib/composable-cow/test/ComposableCoW.base.t.sol";
+import {
+    GPv2Trade,
+    GPv2Interaction,
+    GPv2Signing
+} from "lib/composable-cow/lib/cowprotocol/src/contracts/GPv2Settlement.sol";
+import {GPv2TradeEncoder} from "lib/composable-cow/test/vendored/GPv2TradeEncoder.sol";
+import "lib/composable-cow/src/value_factories/CurrentBlockTimestampFactory.sol";
+import "lib/composable-cow/src/types/twap/TWAP.sol";
 import {FundingModule, IERC20, ISafe} from "../../src/FundingModule.sol";
+import "lib/hooks-trampoline/src/HooksTrampoline.sol";
 
-abstract contract FundingModuleTestHarness is Base {
+abstract contract FundingModuleTestHarness is BaseComposableCoWTest {
+    using SafeLib for Safe;
+    using TestAccountLib for TestAccount;
+
     // --- constants
     uint256 constant FUNDING_AMOUNT = 1_000_000e18;
     uint256 constant AMM_TOKEN0_AMOUNT = 50_000e18;
@@ -14,11 +26,13 @@ abstract contract FundingModuleTestHarness is Base {
 
     // --- variables
     FundingModule fundingModule;
+    HooksTrampoline trampoline;
+    IValueFactory currentBlockTimestampFactory;
     ISafe stagingSafe;
     address fundingSrc;
     address fundingDst;
 
-    function setUp() public virtual override(Base) {
+    function setUp() public virtual override(BaseComposableCoWTest) {
         super.setUp();
 
         stagingSafe = ISafe(address(safe1));
@@ -55,5 +69,135 @@ abstract contract FundingModuleTestHarness is Base {
     function setUpBoughtTokens() internal {
         // deal some tokens to the staging safe to create a residual
         deal(address(token1), address(stagingSafe), BOUGHT_AMOUNT);
+    }
+
+    function setUpTrampoline() internal {
+        // create a trampoline
+        trampoline = new HooksTrampoline(address(settlement));
+    }
+
+    function setUpComposableCow() internal {
+        // deploy the current block timestamp factory
+        currentBlockTimestampFactory = new CurrentBlockTimestampFactory();
+    }
+
+    function getTWAPOrder() internal returns (TWAPOrder.Data memory) {
+        // Assemble the TWAP bundle
+        TWAPOrder.Data memory bundle = TWAPOrder.Data({
+            sellToken: token0,
+            buyToken: token1,
+            receiver: address(stagingSafe),
+            partSellAmount: SELL_AMOUNT,
+            minPartLimit: 1,
+            t0: 0,
+            n: 10,
+            t: 3600,
+            span: 0,
+            // The below appData should be set correctly for the hooks when
+            // used on-chain in the real system.
+            appData: keccak256("twapWithHooks")
+        });
+        return bundle;
+    }
+
+    function settleWithHooks(
+        address who,
+        TestAccount memory counterParty,
+        GPv2Order.Data memory order,
+        bytes memory bundleBytes,
+        bytes4 _revertSelector,
+        HooksTrampoline.Hook[] memory preHooks,
+        HooksTrampoline.Hook[] memory postHooks
+    ) internal {
+        // Generate counter party's order
+        GPv2Order.Data memory counterOrder = GPv2Order.Data({
+            sellToken: order.buyToken,
+            buyToken: order.sellToken,
+            receiver: address(0),
+            sellAmount: order.buyAmount,
+            buyAmount: order.sellAmount,
+            validTo: order.validTo,
+            appData: order.appData,
+            feeAmount: 0,
+            kind: GPv2Order.KIND_BUY,
+            partiallyFillable: false,
+            buyTokenBalance: GPv2Order.BALANCE_ERC20,
+            sellTokenBalance: GPv2Order.BALANCE_ERC20
+        });
+
+        bytes memory counterPartySig =
+            counterParty.signPacked(GPv2Order.hash(counterOrder, settlement.domainSeparator()));
+
+        // Authorize the GPv2VaultRelayer to spend bob's sell token
+        vm.prank(counterParty.addr);
+        IERC20(counterOrder.sellToken).approve(address(relayer), counterOrder.sellAmount);
+
+        // first declare the tokens we will be trading
+        IERC20[] memory tokens = new IERC20[](2);
+        tokens[0] = IERC20(order.sellToken);
+        tokens[1] = IERC20(order.buyToken);
+
+        // second declare the clearing prices
+        uint256[] memory clearingPrices = new uint256[](2);
+        clearingPrices[0] = counterOrder.sellAmount;
+        clearingPrices[1] = counterOrder.buyAmount;
+
+        // third declare the trades
+        GPv2Trade.Data[] memory trades = new GPv2Trade.Data[](2);
+
+        // The safe's order is the first trade
+        trades[0] = GPv2Trade.Data({
+            sellTokenIndex: 0,
+            buyTokenIndex: 1,
+            receiver: order.receiver,
+            sellAmount: order.sellAmount,
+            buyAmount: order.buyAmount,
+            validTo: order.validTo,
+            appData: order.appData,
+            feeAmount: order.feeAmount,
+            flags: GPv2TradeEncoder.encodeFlags(order, GPv2Signing.Scheme.Eip1271),
+            executedAmount: order.sellAmount,
+            signature: abi.encodePacked(who, bundleBytes)
+        });
+
+        // Bob's order is the second trade
+        trades[1] = GPv2Trade.Data({
+            sellTokenIndex: 1,
+            buyTokenIndex: 0,
+            receiver: address(0),
+            sellAmount: counterOrder.sellAmount,
+            buyAmount: counterOrder.buyAmount,
+            validTo: counterOrder.validTo,
+            appData: counterOrder.appData,
+            feeAmount: counterOrder.feeAmount,
+            flags: GPv2TradeEncoder.encodeFlags(counterOrder, GPv2Signing.Scheme.Eip712),
+            executedAmount: counterOrder.sellAmount,
+            signature: counterPartySig
+        });
+
+        // fourth declare the interactions
+        GPv2Interaction.Data[][3] memory interactions =
+            [wrapHooks(preHooks), new GPv2Interaction.Data[](0), wrapHooks(postHooks)];
+
+        // finally we can execute the settlement
+        vm.prank(solver.addr);
+        if (_revertSelector == bytes4(0)) {
+            settlement.settle(tokens, clearingPrices, trades, interactions);
+        } else {
+            vm.expectRevert(_revertSelector);
+            settlement.settle(tokens, clearingPrices, trades, interactions);
+        }
+    }
+
+    function wrapHooks(HooksTrampoline.Hook[] memory hooks)
+        internal
+        returns (GPv2Interaction.Data[] memory trampolined)
+    {
+        trampolined = new GPv2Interaction.Data[](1);
+        trampolined[0] = GPv2Interaction.Data({
+            target: address(trampoline),
+            callData: abi.encodeWithSelector(trampoline.execute.selector, hooks),
+            value: 0
+        });
     }
 }

--- a/test/FundingModule/FundingModuleTestHarness.sol
+++ b/test/FundingModule/FundingModuleTestHarness.sol
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.0 <0.9.0;
+
+import {Base} from "lib/composable-cow/test/Base.t.sol";
+import {FundingModule, IERC20, ISafe} from "../../src/FundingModule.sol";
+
+abstract contract FundingModuleTestHarness is Base {
+    // --- constants
+    uint256 constant FUNDING_AMOUNT = 1_000_000e18;
+    uint256 constant AMM_TOKEN0_AMOUNT = 50_000e18;
+    uint256 constant AMM_TOKEN1_AMOUNT = 100_000e18;
+    uint256 constant SELL_AMOUNT = 10_000e18;
+    uint256 constant BOUGHT_AMOUNT = 20_000e18;
+
+    // --- variables
+    FundingModule fundingModule;
+    ISafe stagingSafe;
+    address fundingSrc;
+    address fundingDst;
+
+    function setUp() public virtual override(Base) {
+        super.setUp();
+
+        stagingSafe = ISafe(address(safe1));
+        fundingSrc = address(safe2);
+        fundingDst = address(safe3);
+
+        // create a funding module
+        fundingModule = new FundingModule(
+            IERC20(address(token0)), IERC20(address(token1)), stagingSafe, fundingSrc, fundingDst, SELL_AMOUNT
+        );
+
+        // enable the funding module on the staging safe
+        vm.prank(address(stagingSafe));
+        safe1.enableModule(address(fundingModule));
+
+        // set the allowance for the staging safe on the funding src
+        vm.prank(address(fundingSrc));
+        token0.approve(address(stagingSafe), FUNDING_AMOUNT);
+    }
+
+    function setUpTokenAmounts() internal {
+        // give some tokens to the funding src
+        deal(address(token0), address(fundingSrc), FUNDING_AMOUNT);
+
+        vm.startPrank(address(stagingSafe));
+        token0.transfer(address(1), token0.balanceOf(address(stagingSafe)));
+        vm.stopPrank();
+    }
+
+    function setUpAmmReserves() internal {
+        // set the reserves of the AMM (deal it some tokens)
+        deal(address(token0), address(fundingDst), AMM_TOKEN0_AMOUNT);
+        deal(address(token1), address(fundingDst), AMM_TOKEN1_AMOUNT);
+    }
+
+    function setUpBoughtTokens() internal {
+        // deal some tokens to the staging safe to create a residual
+        deal(address(token1), address(stagingSafe), BOUGHT_AMOUNT);
+    }
+}

--- a/test/FundingModule/FundingModuleTestHarness.sol
+++ b/test/FundingModule/FundingModuleTestHarness.sol
@@ -40,12 +40,10 @@ abstract contract FundingModuleTestHarness is Base {
     }
 
     function setUpTokenAmounts() internal {
-        // give some tokens to the funding src
-        deal(address(token0), address(fundingSrc), FUNDING_AMOUNT);
-
-        vm.startPrank(address(stagingSafe));
-        token0.transfer(address(1), token0.balanceOf(address(stagingSafe)));
-        vm.stopPrank();
+        // give the funding amount to the funding source
+        deal(address(token0), fundingSrc, FUNDING_AMOUNT);
+        // set the staging safe to have no tokens
+        deal(address(token0), address(stagingSafe), 0);
     }
 
     function setUpAmmReserves() internal {

--- a/test/FundingModule/PullTest.t.sol
+++ b/test/FundingModule/PullTest.t.sol
@@ -14,7 +14,7 @@ contract PullTest is FundingModuleTestHarness {
         fundingModule.pull();
 
         // check that the staging safe has the correct amount of tokens
-        assertEq(token0.balanceOf(address(stagingSafe)), 10000e18);
+        assertEq(token0.balanceOf(address(stagingSafe)), 10_000e18);
     }
 
     function testPullTwiceAssertSingleTransfer() public {
@@ -23,17 +23,17 @@ contract PullTest is FundingModuleTestHarness {
         fundingModule.pull();
 
         // check that the staging safe has the correct amount of tokens
-        assertEq(token0.balanceOf(address(stagingSafe)), 10000e18);
+        assertEq(token0.balanceOf(address(stagingSafe)), 10_000e18);
     }
 
     function testPullWithResidualBalance() public {
         // deal some tokens to the staging safe to create a residual
-        deal(address(token0), address(safe1), 1000e18);
+        deal(address(token0), address(safe1), 1_000e18);
 
         // pull tokens from the funding src to the staging safe
         fundingModule.pull();
 
         // check that the staging safe has the correct amount of tokens
-        assertEq(token0.balanceOf(address(stagingSafe)), 10000e18);
+        assertEq(token0.balanceOf(address(stagingSafe)), 10_000e18);
     }
 }

--- a/test/FundingModule/PullTest.t.sol
+++ b/test/FundingModule/PullTest.t.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.0 <0.9.0;
+
+import {FundingModuleTestHarness, IERC20} from "./FundingModuleTestHarness.sol";
+
+contract PullTest is FundingModuleTestHarness {
+    function setUp() public virtual override(FundingModuleTestHarness) {
+        super.setUp();
+        setUpTokenAmounts();
+    }
+
+    function testSimplePull() public {
+        // pull tokens from the funding src to the staging safe
+        fundingModule.pull();
+
+        // check that the staging safe has the correct amount of tokens
+        assertEq(token0.balanceOf(address(stagingSafe)), 10000e18);
+    }
+
+    function testPullTwiceAssertSingleTransfer() public {
+        // pull tokens from the funding src to the staging safe
+        fundingModule.pull();
+        fundingModule.pull();
+
+        // check that the staging safe has the correct amount of tokens
+        assertEq(token0.balanceOf(address(stagingSafe)), 10000e18);
+    }
+
+    function testPullWithResidualBalance() public {
+        // deal some tokens to the staging safe to create a residual
+        deal(address(token0), address(safe1), 1000e18);
+
+        // pull tokens from the funding src to the staging safe
+        fundingModule.pull();
+
+        // check that the staging safe has the correct amount of tokens
+        assertEq(token0.balanceOf(address(stagingSafe)), 10000e18);
+    }
+}

--- a/test/FundingModule/PushTest.t.sol
+++ b/test/FundingModule/PushTest.t.sol
@@ -15,6 +15,7 @@ contract PushTest is FundingModuleTestHarness {
         fundingModule.push();
 
         // check that the staging safe has the correct amount of tokens
+        // and that it hasn't reverted
         assertEq(token0.balanceOf(address(stagingSafe)), 0);
         assertEq(token1.balanceOf(address(stagingSafe)), 0);
         assertEq(token0.balanceOf(address(fundingDst)), AMM_TOKEN0_AMOUNT);
@@ -27,6 +28,7 @@ contract PushTest is FundingModuleTestHarness {
         fundingModule.push();
 
         // check that the staging safe has the correct amount of tokens
+        // and that it hasn't reverted
         assertEq(token0.balanceOf(address(stagingSafe)), 0);
         assertEq(token1.balanceOf(address(stagingSafe)), 0);
         assertEq(token0.balanceOf(address(fundingDst)), AMM_TOKEN0_AMOUNT);

--- a/test/FundingModule/PushTest.t.sol
+++ b/test/FundingModule/PushTest.t.sol
@@ -1,0 +1,69 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.0 <0.9.0;
+
+import {FundingModuleTestHarness, IERC20} from "./FundingModuleTestHarness.sol";
+
+contract PushTest is FundingModuleTestHarness {
+    function setUp() public virtual override(FundingModuleTestHarness) {
+        super.setUp();
+        setUpTokenAmounts();
+        setUpAmmReserves();
+    }
+
+    function testPushNoStagingBoughtTokens() public {
+        // push tokens from the staging safe to the funding dst
+        fundingModule.push();
+
+        // check that the staging safe has the correct amount of tokens
+        assertEq(token0.balanceOf(address(stagingSafe)), 0);
+        assertEq(token1.balanceOf(address(stagingSafe)), 0);
+        assertEq(token0.balanceOf(address(fundingDst)), AMM_TOKEN0_AMOUNT);
+        assertEq(token1.balanceOf(address(fundingDst)), AMM_TOKEN1_AMOUNT);
+    }
+
+    function testMultiPushNoStagingBoughtTokens() public {
+        // push tokens from the staging safe to the funding dst
+        fundingModule.push();
+        fundingModule.push();
+
+        // check that the staging safe has the correct amount of tokens
+        assertEq(token0.balanceOf(address(stagingSafe)), 0);
+        assertEq(token1.balanceOf(address(stagingSafe)), 0);
+        assertEq(token0.balanceOf(address(fundingDst)), AMM_TOKEN0_AMOUNT);
+        assertEq(token1.balanceOf(address(fundingDst)), AMM_TOKEN1_AMOUNT);
+    }
+
+    function testPushWithStagingBoughtTokens() public {
+        setUpBoughtTokens();
+        // cache destination funding safe balances
+        (uint256 x, uint256 y) = _fetchTokenBalances(address(fundingDst));
+
+        // cache source funding safe balances
+        (uint256 srcToken0Balance, uint256 srcToken1Balance) = _fetchTokenBalances(address(fundingSrc));
+
+        // cache staging safe balances
+        (uint256 stagingToken0Balance, uint256 stagingToken1Balance) = _fetchTokenBalances(address(stagingSafe));
+
+        // push tokens from the staging safe to the funding dst
+        fundingModule.push();
+
+        // Should have perfectly flushed the staging safe
+        assertEq(token0.balanceOf(address(stagingSafe)), 0);
+        assertEq(token1.balanceOf(address(stagingSafe)), 0);
+
+        uint256 deltaY = BOUGHT_AMOUNT;
+
+        // Should have transferred the correct amount of tokens to the dst
+        uint256 deltaX = deltaY * x / y;
+        assertEq(token0.balanceOf(address(fundingDst)), x + deltaX);
+        assertEq(token1.balanceOf(address(fundingDst)), y + deltaY);
+
+        // Do assertions for source safe
+        assertEq(token0.balanceOf(address(fundingSrc)), srcToken0Balance - deltaX);
+        assertEq(token1.balanceOf(address(fundingSrc)), 0);
+    }
+
+    function _fetchTokenBalances(address who) internal view returns (uint256, uint256) {
+        return (token0.balanceOf(who), token1.balanceOf(who));
+    }
+}


### PR DESCRIPTION
This PR:

1. Vendors `SafeERC20` from OpenZeppelin to allow for `SafeERC20` transfers from a `Safe` module to handle various issues surrounding returns from tokens when doing transfers.
2. Implements a module that contains permissionless `pull` and `push` functions that serve as pre and post hooks respectively for a TWAP transaction to fund the AMM.