### PR TITLE
Add minimum amount for creating amm order

### DIFF
--- a/src/interfaces/IPriceOracle.sol
+++ b/src/interfaces/IPriceOracle.sol
@@ -24,7 +24,7 @@ interface IPriceOracle {
      * oracle implementation. For example, it could be a specific pool id for
      * balancer, or the address of a specific price feed for Chainlink.
      * We recommend this data be implemented as the abi-encoding of a dedicated
-     * data struct for ease of type-checking and decoding the input. 
+     * data struct for ease of type-checking and decoding the input.
      * @return priceNumerator The numerator of the price, expressed in amount of
      * token1 per amount of token0.
      * @return priceDenominator The denominator of the price, expressed in

--- a/test/ConstantProduct/ConstantProductTestHarness.sol
+++ b/test/ConstantProduct/ConstantProductTestHarness.sol
@@ -38,6 +38,7 @@ abstract contract ConstantProductTestHarness is BaseComposableCoWTest {
         return ConstantProduct.Data(
             IERC20(USDC),
             IERC20(WETH),
+            0,
             uniswapV2PriceOracle,
             abi.encode(UniswapV2PriceOracle.Data(IUniswapV2Pair(DEFAULT_PAIR))),
             DEFAULT_APPDATA
@@ -80,9 +81,8 @@ abstract contract ConstantProductTestHarness is BaseComposableCoWTest {
     }
 
     // This function calls `getTradeableOrder` while filling all unused
-    // parameters with arbitrary data. Since every tradeable order is supposed
-    // to be executable, it also immediately checks that the order is valid.
-    function getTradeableOrderWrapper(address owner, ConstantProduct.Data memory staticInput)
+    // parameters with arbitrary data.
+    function getTradeableOrderUncheckedWrapper(address owner, ConstantProduct.Data memory staticInput)
         internal
         view
         returns (GPv2Order.Data memory order)
@@ -94,6 +94,17 @@ abstract contract ConstantProductTestHarness is BaseComposableCoWTest {
             abi.encode(staticInput),
             bytes("offchain input")
         );
+    }
+
+    // This function calls `getTradeableOrder` while filling all unused
+    // parameters with arbitrary data. It also immediately checks that the order
+    // is valid.
+    function getTradeableOrderWrapper(address owner, ConstantProduct.Data memory staticInput)
+        internal
+        view
+        returns (GPv2Order.Data memory order)
+    {
+        order = getTradeableOrderUncheckedWrapper(owner, staticInput);
         verifyWrapper(owner, staticInput, order);
     }
 

--- a/test/ConstantProduct/verify/ValidateAmmMath.sol
+++ b/test/ConstantProduct/verify/ValidateAmmMath.sol
@@ -40,6 +40,7 @@ abstract contract ValidateAmmMath is ConstantProductTestHarness {
         data = ConstantProduct.Data(
             order.sellToken,
             order.buyToken,
+            0,
             uniswapV2PriceOracle,
             abi.encode(abi.encode(UniswapV2PriceOracle.Data(pair))),
             order.appData


### PR DESCRIPTION
This PR adds a check on `getTradeableOrder` that causes it to revert if the traded amount is too low.

This is to add a barrier to avoid that the AMM creates orders in the orderbook that are very unlikely to be filled and would just be noise in the AMM order page.