### PR TITLE
Fix encoding of transaction data in docs

### DIFF
--- a/docs/amm.md
+++ b/docs/amm.md
@@ -64,7 +64,7 @@ minTradedToken0=31337
 priceOracle=0x1337133713371337133713371337133713371337
 priceOracleData=0xca11d47a
 appData=0x3232323232323232323232323232323232323232323232323232323232323232
-cast abi-encode 'f(address,address,uint256,address,bytes,bytes32)' "$token0" "$token1" "$minTradedToken0" "$priceOracle" "$priceOracleData" "$appData"
+cast abi-encode 'f((address,address,uint256,address,bytes,bytes32))' "($token0, $token1, $minTradedToken0, $priceOracle, $priceOracleData, $appData)"
 ```
 
 ### Supported price oracles
@@ -89,7 +89,7 @@ If the tokens are not the same as those traded on the chosen reference pair, no 
 If Foundry is available in your system, you can generate the bytes calldata with the following command:
 ```sh
 referencePair=0x1111111111111111111111111111111111111111
-cast abi-encode 'f(address)' "$referencePair"
+cast abi-encode 'f((address))' "($referencePair)"
 ```
 
 ## Risk profile


### PR DESCRIPTION
The commands in the docs encode the data as if each entry was part of the input to a function, but we need to encode all entries together in a single tuple.

This code updates the command.

The command used is how the docs encode a tuple in the [examples](https://book.getfoundry.sh/reference/cast/cast-abi-encode#examples).

### How to test

This code has been used on a [test AMM on Sepolia](https://app.safe.global/transactions/history?safe=sep:0xe2f780347649d579452d6dc6960a197e6424580c). You can check on the CoW Explorer that the AMM is working as expected and that the data was generated with this code.

<details><summary>Other commands</summary>

The calldata in a `create` transaction can be decoded with:

```sh
calldata='0xINSERTCALLDATAHERE'
cast calldata-decode 'create((address,bytes32,bytes), bool)' "$calldata"
static_input='0xSTATICINPUTFROMPREVIOUSDECODING'
cast abi-decode --input 'f((address,address,uint256,address,bytes,bytes32))' "$static_input"
```
</details>