### PR TITLE
Account for subtraction underflow in order creation

### DIFF
--- a/test/ConstantProduct/getTradeableOrder/ValidateOrderParametersTest.sol
+++ b/test/ConstantProduct/getTradeableOrder/ValidateOrderParametersTest.sol
@@ -7,7 +7,7 @@ import {IWatchtowerCustomErrors} from "src/interfaces/IWatchtowerCustomErrors.so
 
 abstract contract ValidateOrderParametersTest is ConstantProductTestHarness {
     function testValidOrderParameters() public {
-        ConstantProduct.Data memory defaultData = setUpDefaultData();
+        ConstantProduct.Data memory defaultData = getDefaultData();
         setUpDefaultReserves(orderOwner);
         setUpDefaultReferencePairReserves(42, 1337);
 
@@ -24,7 +24,7 @@ abstract contract ValidateOrderParametersTest is ConstantProductTestHarness {
     }
 
     function testOrderValidityMovesToNextBucket() public {
-        ConstantProduct.Data memory defaultData = setUpDefaultData();
+        ConstantProduct.Data memory defaultData = getDefaultData();
         setUpDefaultReserves(orderOwner);
         setUpDefaultReferencePairReserves(42, 1337);
 
@@ -41,19 +41,11 @@ abstract contract ValidateOrderParametersTest is ConstantProductTestHarness {
     }
 
     function testRevertsIfAmountTooLowOnSellToken() public {
-        ConstantProduct.Data memory defaultData = setUpDefaultData();
+        ConstantProduct.Data memory defaultData = getDefaultData();
         setUpDefaultReserves(orderOwner);
         setUpDefaultReferencePairReserves(42, 1337);
 
-        uint256 smallOffset = 42;
-        require(smallOffset < constantProduct.MAX_ORDER_DURATION());
-        uint256 nextTimestamp = 1337 * constantProduct.MAX_ORDER_DURATION() + smallOffset;
-        uint256 nextBucket = 1338 * constantProduct.MAX_ORDER_DURATION();
-        require(
-            nextTimestamp % constantProduct.MAX_ORDER_DURATION() != 0,
-            "test was designed so that the timestamp doesn't fall exactly at the start of a bucket, please change the offset"
-        );
-        vm.warp(nextTimestamp);
+        uint256 nextBucket = moveTimeToMidFutureBucket();
 
         GPv2Order.Data memory order = getTradeableOrderWrapper(orderOwner, defaultData);
         require(order.sellToken == defaultData.token0, "test was design for token0 to be the sell token");
@@ -69,19 +61,11 @@ abstract contract ValidateOrderParametersTest is ConstantProductTestHarness {
     }
 
     function testRevertsIfAmountTooLowOnBuyToken() public {
-        ConstantProduct.Data memory defaultData = setUpDefaultData();
+        ConstantProduct.Data memory defaultData = getDefaultData();
         setUpDefaultReserves(orderOwner);
         setUpDefaultReferencePairReserves(1337, 42);
 
-        uint256 smallOffset = 42;
-        require(smallOffset < constantProduct.MAX_ORDER_DURATION());
-        uint256 nextTimestamp = 1337 * constantProduct.MAX_ORDER_DURATION() + smallOffset;
-        uint256 nextBucket = 1338 * constantProduct.MAX_ORDER_DURATION();
-        require(
-            nextTimestamp % constantProduct.MAX_ORDER_DURATION() != 0,
-            "test was designed so that the timestamp doesn't fall exactly at the start of a bucket, please change the offset"
-        );
-        vm.warp(nextTimestamp);
+        uint256 nextBucket = moveTimeToMidFutureBucket();
 
         GPv2Order.Data memory order = getTradeableOrderWrapper(orderOwner, defaultData);
         require(order.buyToken == defaultData.token0, "test was design for token0 to be the buy token");
@@ -94,5 +78,34 @@ abstract contract ValidateOrderParametersTest is ConstantProductTestHarness {
             )
         );
         getTradeableOrderUncheckedWrapper(orderOwner, defaultData);
+    }
+
+    function testSellAmountSubtractionUnderflow() public {
+        ConstantProduct.Data memory defaultData = getDefaultData();
+        (uint256 selfReserve0, uint256 selfReserve1) = (1337, 1337);
+        (uint256 uniswapReserve0, uint256 uniswapReserve1) = (1, 1);
+        setUpDefaultWithReserves(orderOwner, selfReserve0, selfReserve1);
+        setUpDefaultReferencePairReserves(uniswapReserve0, uniswapReserve1);
+
+        uint256 nextBucket = moveTimeToMidFutureBucket();
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IWatchtowerCustomErrors.PollTryAtEpoch.selector, nextBucket + 1, "subtraction underflow"
+            )
+        );
+        getTradeableOrderUncheckedWrapper(orderOwner, defaultData);
+    }
+
+    function moveTimeToMidFutureBucket() internal returns (uint256 nextBucketStart) {
+        uint256 smallOffset = 42;
+        require(smallOffset < constantProduct.MAX_ORDER_DURATION());
+        uint256 nextTimestamp = 1337 * constantProduct.MAX_ORDER_DURATION() + smallOffset;
+        nextBucketStart = 1338 * constantProduct.MAX_ORDER_DURATION();
+        require(
+            nextTimestamp % constantProduct.MAX_ORDER_DURATION() != 0,
+            "test was designed so that the timestamp doesn't fall exactly at the start of a bucket, please change the offset"
+        );
+        vm.warp(nextTimestamp);
     }
 }


### PR DESCRIPTION
This PR adds an explicit underflow check for the subtractions in the `getTradeableOrder` function.

This is done because a revert due to underflow during a watchtower call to `getTradeableOrder` would cause the watchtower to stop indexing AMM order, stopping the automated order creation on the orderbook until the order is deleted and then recreated.

Note that we're mainly concerned about subtraction overflows. We're leaving all multiplication and addition overflow there because they are only likely to occur when the amounts are so large that they are close to the amount the CoW AMM isn't able to handle by design. In the case of subtraction, an underflow could happen when the AMM reserves are extremely close to the reference price. This may occur by chance for pairs with tokens that have low number of decimals, like USDC.

### How to test

New unit test. Note that I changed `setUpDefaultData` to `getDefaultData` when we set the reserves by hand because otherwise there'd be two mocks set for the same oracle/pair.