### PR TITLE
Add disclaimer to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 > [!CAUTION]
 > CoW AMM is a proof of concept of an AMM implemented on top of CoW Protocol.
 > The code is not yet production ready and should not be used to handle large amounts of funds.
+> For technical aspects of the smart contract, reach out to us on [discord](https://discord.com/invite/cowprotocol) as we push towards production, or simply star the repository to be informed of progress!
 
 CoW AMM is an automated market maker running on top of CoW Protocol.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-## CoW AMM
+# CoW AMM
+
+> [!CAUTION]
+> CoW AMM is a proof of concept of an AMM implemented on top of CoW Protocol.
+> The code is not yet production ready and should not be used to handle large amounts of funds.
 
 CoW AMM is an automated market maker running on top of CoW Protocol.
 

--- a/docs/amm.md
+++ b/docs/amm.md
@@ -5,6 +5,7 @@ CoW AMM is an automated market maker running on top of CoW Protocol.
 > [!CAUTION]
 > CoW AMM is a proof of concept of an AMM implemented on top of CoW Protocol.
 > The code is not yet production ready and should not be used to handle large amounts of funds.
+> For technical aspects of the smart contract, reach out to us on [discord](https://discord.com/invite/cowprotocol) as we push towards production, or simply star the repository to be informed of progress!
 
 ## How it works
 

--- a/docs/amm.md
+++ b/docs/amm.md
@@ -2,6 +2,10 @@
 
 CoW AMM is an automated market maker running on top of CoW Protocol.
 
+> [!CAUTION]
+> CoW AMM is a proof of concept of an AMM implemented on top of CoW Protocol.
+> The code is not yet production ready and should not be used to handle large amounts of funds.
+
 ## How it works
 
 The AMM contract itself is a dedicated Safe multisig.


### PR DESCRIPTION
Adds disclaimer in preparation for the launch.
We want to stress that the AMM is still work in progress.

More info on the specific Markdown syntax [here](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax#alerts).