### PR TITLE
Add Balancer weighted pool price oracle

### DIFF
--- a/src/interfaces/IBalancer.sol
+++ b/src/interfaces/IBalancer.sol
@@ -42,36 +42,18 @@ interface IVault {
     function getPool(bytes32 poolId) external view returns (address, PoolSpecialization);
 
     /**
-     * @dev Called by users to join a Pool, which transfers tokens from `sender` into the Pool's balance. This will
-     * trigger custom Pool behavior, which will typically grant something in return to `recipient` - often tokenized
-     * Pool shares.
+     * @dev Returns a Pool's registered tokens, the total balance for each, and the latest block when *any* of
+     * the tokens' `balances` changed.
      *
-     * If the caller is not `sender`, it must be an authorized relayer for them.
+     * The order of the `tokens` array is the same order that will be used in `joinPool`, `exitPool`, as well as in all
+     * Pool hooks (where applicable). Calls to `registerTokens` and `deregisterTokens` may change this order.
      *
-     * The `assets` and `maxAmountsIn` arrays must have the same length, and each entry indicates the maximum amount
-     * to send for each asset. The amounts to send are decided by the Pool and not the Vault: it just enforces
-     * these maximums.
+     * If a Pool only registers tokens once, and these are sorted in ascending order, they will be stored in the same
+     * order as passed to `registerTokens`.
      *
-     * If joining a Pool that holds WETH, it is possible to send ETH directly: the Vault will do the wrapping. To enable
-     * this mechanism, the IAsset sentinel value (the zero address) must be passed in the `assets` array instead of the
-     * WETH address. Note that it is not possible to combine ETH and WETH in the same join. Any excess ETH will be sent
-     * back to the caller (not the sender, which is important for relayers).
-     *
-     * `assets` must have the same length and order as the array returned by `getPoolTokens`. This prevents issues when
-     * interacting with Pools that register and deregister tokens frequently. If sending ETH however, the array must be
-     * sorted *before* replacing the WETH address with the ETH sentinel value (the zero address), which means the final
-     * `assets` array might not be sorted. Pools with no registered tokens cannot be joined.
-     *
-     * If `fromInternalBalance` is true, the caller's Internal Balance will be preferred: ERC20 transfers will only
-     * be made for the difference between the requested amount and Internal Balance (if any). Note that ETH cannot be
-     * withdrawn from Internal Balance: attempting to do so will trigger a revert.
-     *
-     * This causes the Vault to call the `IBasePool.onJoinPool` hook on the Pool's contract, where Pools implement
-     * their own custom logic. This typically requires additional information from the user (such as the expected number
-     * of Pool shares). This can be encoded in the `userData` argument, which is ignored by the Vault and passed
-     * directly to the Pool's contract, as is `recipient`.
-     *
-     * Emits a `PoolBalanceChanged` event.
+     * Total balances include both tokens held by the Vault and those withdrawn by the Pool's Asset Managers. These are
+     * the amounts used by joins, exits and swaps. For a detailed breakdown of token balances, use `getPoolTokenInfo`
+     * instead.
      */
     function getPoolTokens(bytes32 poolId)
         external

--- a/src/interfaces/IBalancer.sol
+++ b/src/interfaces/IBalancer.sol
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import {IERC20} from "lib/composable-cow/lib/@openzeppelin/contracts/interfaces/IERC20.sol";
+
+/**
+ * @title Balancer Vault Interface
+ * @author CoW Protocol Developers
+ * @dev This is an abridged version of the Balancer Vault interface that can be found at:
+ * <https://github.com/balancer/balancer-v2-monorepo/blob/ac63d64018c6331248c7d77b9f317a06cced0243/pkg/interfaces/contracts/vault/IVault.sol>
+ * All code is copied from that link except:
+ *  - Autoformatting.
+ *  - Import path of `IERC20`.
+ */
+interface IVault {
+    // Pools
+    //
+    // There are three specialization settings for Pools, which allow for cheaper swaps at the cost of reduced
+    // functionality:
+    //
+    //  - General: no specialization, suited for all Pools. IGeneralPool is used for swap request callbacks, passing the
+    // balance of all tokens in the Pool. These Pools have the largest swap costs (because of the extra storage reads),
+    // which increase with the number of registered tokens.
+    //
+    //  - Minimal Swap Info: IMinimalSwapInfoPool is used instead of IGeneralPool, which saves gas by only passing the
+    // balance of the two tokens involved in the swap. This is suitable for some pricing algorithms, like the weighted
+    // constant product one popularized by Balancer V1. Swap costs are smaller compared to general Pools, and are
+    // independent of the number of registered tokens.
+    //
+    //  - Two Token: only allows two tokens to be registered. This achieves the lowest possible swap gas cost. Like
+    // minimal swap info Pools, these are called via IMinimalSwapInfoPool.
+
+    enum PoolSpecialization {
+        GENERAL,
+        MINIMAL_SWAP_INFO,
+        TWO_TOKEN
+    }
+
+    /**
+     * @dev Returns a Pool's contract address and specialization setting.
+     */
+    function getPool(bytes32 poolId) external view returns (address, PoolSpecialization);
+
+    /**
+     * @dev Called by users to join a Pool, which transfers tokens from `sender` into the Pool's balance. This will
+     * trigger custom Pool behavior, which will typically grant something in return to `recipient` - often tokenized
+     * Pool shares.
+     *
+     * If the caller is not `sender`, it must be an authorized relayer for them.
+     *
+     * The `assets` and `maxAmountsIn` arrays must have the same length, and each entry indicates the maximum amount
+     * to send for each asset. The amounts to send are decided by the Pool and not the Vault: it just enforces
+     * these maximums.
+     *
+     * If joining a Pool that holds WETH, it is possible to send ETH directly: the Vault will do the wrapping. To enable
+     * this mechanism, the IAsset sentinel value (the zero address) must be passed in the `assets` array instead of the
+     * WETH address. Note that it is not possible to combine ETH and WETH in the same join. Any excess ETH will be sent
+     * back to the caller (not the sender, which is important for relayers).
+     *
+     * `assets` must have the same length and order as the array returned by `getPoolTokens`. This prevents issues when
+     * interacting with Pools that register and deregister tokens frequently. If sending ETH however, the array must be
+     * sorted *before* replacing the WETH address with the ETH sentinel value (the zero address), which means the final
+     * `assets` array might not be sorted. Pools with no registered tokens cannot be joined.
+     *
+     * If `fromInternalBalance` is true, the caller's Internal Balance will be preferred: ERC20 transfers will only
+     * be made for the difference between the requested amount and Internal Balance (if any). Note that ETH cannot be
+     * withdrawn from Internal Balance: attempting to do so will trigger a revert.
+     *
+     * This causes the Vault to call the `IBasePool.onJoinPool` hook on the Pool's contract, where Pools implement
+     * their own custom logic. This typically requires additional information from the user (such as the expected number
+     * of Pool shares). This can be encoded in the `userData` argument, which is ignored by the Vault and passed
+     * directly to the Pool's contract, as is `recipient`.
+     *
+     * Emits a `PoolBalanceChanged` event.
+     */
+    function getPoolTokens(bytes32 poolId)
+        external
+        view
+        returns (IERC20[] memory tokens, uint256[] memory balances, uint256 lastChangeBlock);
+}
+
+/**
+ * @title Balancer Weighted Pool Interface
+ * @author CoW Protocol Developers
+ * @dev This is an interface for the Balancer weighted pool type. It can be
+ * found at:
+ * <https://github.com/balancer/balancer-v2-monorepo/blob/ac63d64018c6331248c7d77b9f317a06cced0243/pkg/pool-weighted/contracts/BaseWeightedPool.sol#L99-L101>
+ * The comment has been added for clarification.
+ */
+interface IWeightedPool {
+    /**
+     * @notice Returns all normalized weights, in the same order as the Pool's tokens.
+     */
+    function getNormalizedWeights() external view returns (uint256[] memory);
+}

--- a/src/oracles/BalancerWeightedPoolPriceOracle.sol
+++ b/src/oracles/BalancerWeightedPoolPriceOracle.sol
@@ -116,7 +116,7 @@ contract BalancerWeightedPoolPriceOracle is IPriceOracle {
      * @dev The two input values are truncated off their least significant bits
      * by the same number of bits while trying to make them fit 128 bits.
      * The number of bits that is truncated is always the same for both values.
-     * If truncating meant that less significan bits than `TOLERANCE` remained,
+     * If truncating meant that less significant bits than `TOLERANCE` remained,
      * then this function truncates less to preserve `TOLERANCE` bits in the
      * smallest value, even if one of the output values ends up having more than
      * 128 bits of size.

--- a/src/oracles/BalancerWeightedPoolPriceOracle.sol
+++ b/src/oracles/BalancerWeightedPoolPriceOracle.sol
@@ -109,6 +109,10 @@ contract BalancerWeightedPoolPriceOracle is IPriceOracle {
         uint256 priceNumerator = balanceToken0 * weightToken1;
         uint256 priceDenominator = balanceToken1 * weightToken0;
 
+        // Numerator and denominator are very likely to be large. We limit the
+        // bit size of the output as recommended in the IPriceOracle interface
+        // so that this price oracle doesn't cause unexpected overflow reverts
+        // when used by `getTradeableOrder`.
         return reduceOutputBytes(priceNumerator, priceDenominator);
     }
 

--- a/src/oracles/BalancerWeightedPoolPriceOracle.sol
+++ b/src/oracles/BalancerWeightedPoolPriceOracle.sol
@@ -1,0 +1,151 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import {IConditionalOrder} from "lib/composable-cow/src/BaseConditionalOrder.sol";
+import {IERC20} from "lib/composable-cow/lib/@openzeppelin/contracts/interfaces/IERC20.sol";
+import {Math} from "lib/composable-cow/lib/@openzeppelin/contracts/utils/math/Math.sol";
+
+import {IVault, IWeightedPool} from "../interfaces/IBalancer.sol";
+import {IPriceOracle} from "../interfaces/IPriceOracle.sol";
+
+/**
+ * @title CoW AMM Balancer Weighted Price Oracle
+ * @author CoW Protocol Developers
+ * @dev This contract creates an oracle that is compatible with the IPriceOracle
+ * interface and can be used by a CoW AMM to determine the current price of the
+ * traded tokens on specific Balancer weighted pools.
+ * No other Balancer pool type is supported.
+ */
+contract BalancerWeightedPoolPriceOracle is IPriceOracle {
+    /**
+     * Address of the Balancer vault.
+     */
+    IVault public vault;
+
+    /**
+     * Data required by the oracle to determine the current price.
+     */
+    struct Data {
+        /**
+         * The Balancer poolId that references an instance of a weighted pool.
+         * Note that the contract doesn't verify that the pool is indeed a
+         * weighted pool. If the id refers to another type of pool, then the
+         * oracle may return an incorrect price.
+         */
+        bytes32 poolId;
+    }
+
+    /**
+     * How many significant bits should be preserved from truncation.
+     */
+    uint256 public constant TOLERANCE = 14;
+
+    /**
+     * @param vault_ The address of the Balancer vault in the current chain.
+     */
+    constructor(IVault vault_) {
+        vault = vault_;
+    }
+
+    /**
+     * @inheritdoc IPriceOracle
+     */
+    function getPrice(address token0, address token1, bytes calldata data) external view returns (uint256, uint256) {
+        IWeightedPool pool;
+        IERC20[] memory tokens;
+        uint256[] memory balances;
+        uint256[] memory weights;
+        {
+            // Note: function calls in this scope aren't affected by the paused
+            // state
+            bytes32 poolId = abi.decode(data, (Data)).poolId;
+            // If the pool isn't registered, then the next call reverts
+            try vault.getPool(poolId) returns (address a, IVault.PoolSpecialization) {
+                pool = IWeightedPool(a);
+            } catch (bytes memory) {
+                revert IConditionalOrder.OrderNotValid("invalid pool id");
+            }
+
+            (tokens, balances,) = vault.getPoolTokens(poolId);
+
+            // Unfortunately, this function is available also for pools that
+            // aren't weighted pools
+            try pool.getNormalizedWeights() returns (uint256[] memory weights_) {
+                weights = weights_;
+            } catch (bytes memory) {
+                revert IConditionalOrder.OrderNotValid("not a weighted pool");
+            }
+        }
+
+        uint256 weightToken0 = 0;
+        uint256 weightToken1 = 0;
+        uint256 balanceToken0;
+        uint256 balanceToken1;
+        for (uint256 i; i < tokens.length;) {
+            address token;
+            unchecked {
+                token = address(tokens[i]);
+            }
+            if (token == token0) {
+                weightToken0 = weights[i];
+                balanceToken0 = balances[i];
+            } else if (token == token1) {
+                weightToken1 = weights[i];
+                balanceToken1 = balances[i];
+            }
+            unchecked {
+                i++;
+            }
+        }
+
+        if (weightToken0 == 0) {
+            revert IConditionalOrder.OrderNotValid("pool does not trade token0");
+        }
+        if (weightToken1 == 0) {
+            revert IConditionalOrder.OrderNotValid("pool does not trade token1");
+        }
+
+        // https://docs.balancer.fi/reference/math/weighted-math.html#spot-price
+        uint256 priceNumerator = balanceToken0 * weightToken1;
+        uint256 priceDenominator = balanceToken1 * weightToken0;
+
+        return reduceOutputBytes(priceNumerator, priceDenominator);
+    }
+
+    /**
+     * @dev The two input values are truncated off their least significant bits
+     * by the same number of bits while trying to make them fit 128 bits.
+     * The number of bits that is truncated is always the same for both values.
+     * If truncating meant that less significan bits than `TOLERANCE` remained,
+     * then this function truncates less to preserve `TOLERANCE` bits in the
+     * smallest value, even if one of the output values ends up having more than
+     * 128 bits of size.
+     * @param num1 First input value.
+     * @param num2 Second input value.
+     * @return The two original input values in the original order with some of
+     * the least significant bits truncated.
+     */
+    function reduceOutputBytes(uint256 num1, uint256 num2) internal pure returns (uint256, uint256) {
+        uint256 max;
+        uint256 min;
+        if (num1 > num2) {
+            (max, min) = (num1, num2);
+        } else {
+            (max, min) = (num2, num1);
+        }
+        uint256 logMax = Math.log2(max, Math.Rounding.Up);
+        uint256 logMin = Math.log2(min, Math.Rounding.Down);
+
+        if ((logMax <= 128) || (logMin <= TOLERANCE)) {
+            return (num1, num2);
+        }
+        uint256 shift;
+        unchecked {
+            shift = logMax - 128;
+            if (logMin < TOLERANCE + shift) {
+                shift = logMin - TOLERANCE;
+            }
+        }
+        return (num1 >> shift, num2 >> shift);
+    }
+}

--- a/test/oracles/BalancerWeightedPoolPriceOracle.sol
+++ b/test/oracles/BalancerWeightedPoolPriceOracle.sol
@@ -1,0 +1,251 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import "forge-std/Test.sol";
+
+import {IERC20} from "lib/composable-cow/lib/@openzeppelin/contracts/interfaces/IERC20.sol";
+
+import {Utils} from "test/libraries/Utils.sol";
+import {
+    BalancerWeightedPoolPriceOracle,
+    IVault,
+    IWeightedPool,
+    IConditionalOrder
+} from "src/oracles/BalancerWeightedPoolPriceOracle.sol";
+
+contract BalancerWeightedPoolPriceOracleTest is Test {
+    IERC20 private USDC = IERC20(Utils.addressFromString("USDC"));
+    IERC20 private WETH = IERC20(Utils.addressFromString("WETH"));
+    // Technically, the first 20 bytes should be the pool address.
+    // However, this property is not relied on by the Balancer price oracle.
+    bytes32 private DEFAULT_POOL_ID = keccak256("Default Balancer pool id");
+    IWeightedPool internal pool = IWeightedPool(Utils.addressFromString("Balancer vault"));
+    IVault internal balancerVault = IVault(Utils.addressFromString("Balancer pool"));
+    BalancerWeightedPoolPriceOracle internal oracle;
+
+    function setUp() public {
+        oracle = new BalancerWeightedPoolPriceOracle(balancerVault);
+    }
+
+    function testRevertsIfPoolNotRegistered() public {
+        vm.mockCallRevert(
+            address(balancerVault), abi.encodeCall(IVault.getPool, (DEFAULT_POOL_ID)), abi.encode("pool not registered")
+        );
+
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, "invalid pool id"));
+        oracle.getPrice(address(USDC), address(WETH), getDefaultData());
+    }
+
+    function testRevertsIfNoTokensAvailable() public {
+        registerPoolOnVault();
+        vm.mockCallRevert(
+            address(balancerVault),
+            abi.encodeCall(IVault.getPoolTokens, (DEFAULT_POOL_ID)),
+            abi.encode("Test with no tokens available")
+        );
+
+        // There is no custom revert message because we already checked that the
+        // pool is registered. We don't expect this function to revert at this
+        // point.
+        vm.expectRevert();
+        oracle.getPrice(address(USDC), address(WETH), getDefaultData());
+    }
+
+    function testRevertsIfNoWeightsAvailable() public {
+        registerPoolOnVault();
+        setUpDefaultBalancerPool(new IERC20[](0), new uint256[](0), new uint256[](0));
+        vm.mockCallRevert(
+            address(pool),
+            abi.encodeCall(IWeightedPool.getNormalizedWeights, ()),
+            abi.encode("Called unexpected function on mock vault")
+        );
+
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, "not a weighted pool"));
+        oracle.getPrice(address(USDC), address(WETH), getDefaultData());
+    }
+
+    function testRevertsIfToken0IsNotPartOfThePool() public {
+        IERC20[] memory tokens = new IERC20[](1);
+        uint256[] memory balances = new uint256[](1);
+        uint256[] memory weights = new uint256[](1);
+        tokens[0] = WETH;
+        balances[0] = 1337;
+        weights[0] = 42;
+        setUpDefaultBalancerPool(tokens, balances, weights);
+
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, "pool does not trade token0"));
+        oracle.getPrice(address(USDC), address(WETH), getDefaultData());
+    }
+
+    function testRevertsIfToken1IsNotPartOfThePool() public {
+        IERC20[] memory tokens = new IERC20[](1);
+        uint256[] memory balances = new uint256[](1);
+        uint256[] memory weights = new uint256[](1);
+        tokens[0] = USDC;
+        balances[0] = 1337;
+        weights[0] = 42;
+        setUpDefaultBalancerPool(tokens, balances, weights);
+
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, "pool does not trade token1"));
+        oracle.getPrice(address(USDC), address(WETH), getDefaultData());
+    }
+
+    function testComputesExpectedPriceWithUniformWeights() public {
+        IERC20[] memory tokens = new IERC20[](2);
+        uint256[] memory balances = new uint256[](2);
+        uint256[] memory weights = new uint256[](2);
+        tokens[0] = USDC;
+        balances[0] = 200_000 ether;
+        weights[0] = 0.5 ether;
+        tokens[1] = WETH;
+        balances[1] = 100 ether;
+        weights[1] = 0.5 ether;
+        setUpDefaultBalancerPool(tokens, balances, weights);
+
+        (uint256 num, uint256 den) = oracle.getPrice(address(USDC), address(WETH), getDefaultData());
+        assertEq(num / den, 2000);
+    }
+
+    function testComputesExpectedPriceWithUniformWeightsInvertedOrder() public {
+        IERC20[] memory tokens = new IERC20[](2);
+        uint256[] memory balances = new uint256[](2);
+        uint256[] memory weights = new uint256[](2);
+        tokens[0] = USDC;
+        balances[0] = 200_000 ether;
+        weights[0] = 0.5 ether;
+        tokens[1] = WETH;
+        balances[1] = 100 ether;
+        weights[1] = 0.5 ether;
+        setUpDefaultBalancerPool(tokens, balances, weights);
+
+        (uint256 num, uint256 den) = oracle.getPrice(address(WETH), address(USDC), getDefaultData());
+        // Inverting the fraction to still get an integer price
+        assertEq(den / num, 2000);
+    }
+
+    function testRobustForMultipleTokens() public {
+        IERC20[] memory tokens = new IERC20[](4);
+        uint256[] memory balances = new uint256[](4);
+        uint256[] memory weights = new uint256[](4);
+        tokens[0] = IERC20(Utils.addressFromString("some other token"));
+        balances[0] = 1337;
+        weights[0] = 0.25 ether;
+        tokens[1] = USDC;
+        balances[1] = 200_000 ether;
+        weights[1] = 0.25 ether;
+        tokens[2] = IERC20(Utils.addressFromString("again some other token"));
+        balances[2] = 42;
+        weights[2] = 0.25 ether;
+        tokens[3] = WETH;
+        balances[3] = 100 ether;
+        weights[3] = 0.25 ether;
+        setUpDefaultBalancerPool(tokens, balances, weights);
+
+        (uint256 num, uint256 den) = oracle.getPrice(address(USDC), address(WETH), getDefaultData());
+        assertEq(num / den, 2000);
+    }
+
+    function testPriceWithNonUniformWeights() public {
+        IERC20[] memory tokens = new IERC20[](2);
+        uint256[] memory balances = new uint256[](2);
+        uint256[] memory weights = new uint256[](2);
+        uint256 weightAdjustment = 4;
+        tokens[0] = USDC;
+        balances[0] = 200_000 ether * weightAdjustment;
+        weights[0] = 0.8 ether;
+        tokens[1] = WETH;
+        balances[1] = 100 ether;
+        weights[1] = 0.2 ether;
+        setUpDefaultBalancerPool(tokens, balances, weights);
+
+        (uint256 num, uint256 den) = oracle.getPrice(address(USDC), address(WETH), getDefaultData());
+
+        assertEq(num / den, 2000);
+    }
+
+    function testPriceFromActualCowWethPoolValues() public {
+        // Test with COW/WETH pool 0xde8c195aa41c11a0c4787372defbbddaa31306d2000200000000000000000181
+        // Values from Etherscan
+        IERC20 COW = IERC20(Utils.addressFromString("COW"));
+        IERC20[] memory tokens = new IERC20[](2);
+        uint256[] memory balances = new uint256[](2);
+        uint256[] memory weights = new uint256[](2);
+        tokens[0] = WETH;
+        balances[0] = 241480622098035103541;
+        weights[0] = 500000000000000000;
+        tokens[1] = COW;
+        balances[1] = 1489620988536903135970336;
+        weights[1] = 500000000000000000;
+        setUpDefaultBalancerPool(tokens, balances, weights);
+
+        (uint256 num, uint256 den) = oracle.getPrice(address(COW), address(WETH), getDefaultData());
+
+        assertEq(num / den, 6168);
+        // The price is close to the last onchain trade involving this pool:
+        // https://etherscan.io/tx/0x0bc57c87344b8908de3799c244559d177b6b74fc332391aa411a64a2f06d2461
+    }
+
+    function testPriceFromActualComplexPoolValues() public {
+        // Test with Balancer 50KNC-25WETH-25USDC 0x6f0ed6f346007563d3266de350d174a831bde0ca0001000000000000000005db
+        // Values from Etherscan
+        IERC20 KNC = IERC20(Utils.addressFromString("COW"));
+        IERC20[] memory tokens = new IERC20[](3);
+        uint256[] memory balances = new uint256[](3);
+        uint256[] memory weights = new uint256[](3);
+        tokens[0] = USDC;
+        balances[0] = 1155058399278;
+        weights[0] = 250000000000000000;
+        tokens[1] = WETH;
+        balances[1] = 432325169965725108980;
+        weights[1] = 250000000000000000;
+        tokens[2] = KNC;
+        balances[2] = 3648449922658503230449855;
+        weights[2] = 500000000000000000;
+        setUpDefaultBalancerPool(tokens, balances, weights);
+
+        uint256 decimalAdjustment = 10 ** 18 / 10 ** 6;
+        (uint256 num1, uint256 den1) = oracle.getPrice(address(USDC), address(WETH), getDefaultData());
+        assertEq(num1 * decimalAdjustment / den1, 2671);
+        // The price is close to the last onchain trade involving this pool and tokens:
+        // https://etherscan.io/tx/0x30a83c1be9a335b3e62467c4da2eb82700a331730cc66f4dc2efb6b20d229ea7
+
+        (uint256 num2, uint256 den2) = oracle.getPrice(address(KNC), address(USDC), getDefaultData());
+        // Multiply by 1000 because the price is ~1.579 and rounding would cause
+        // the decimals to be truncated.
+        assertEq(1000 * num2 / (den2 * decimalAdjustment), 1579);
+        // The price is close to the last onchain trade involving this pool and tokens:
+        // https://etherscan.io/tx/0xf5e33f63110a3ea4d8fd2a8c024ea5d3e382032e3443def987f2b85ac43853c6
+    }
+
+    function registerPoolOnVault() internal {
+        vm.mockCall(
+            address(balancerVault),
+            abi.encodeCall(IVault.getPool, (DEFAULT_POOL_ID)),
+            abi.encode(address(pool), IVault.PoolSpecialization.GENERAL)
+        );
+    }
+
+    function registerTokensAndBalancesOnVault(IERC20[] memory tokens, uint256[] memory balances) internal {
+        uint256 lastChangeBlock = 1337;
+        vm.mockCall(
+            address(balancerVault),
+            abi.encodeCall(IVault.getPoolTokens, (DEFAULT_POOL_ID)),
+            abi.encode(tokens, balances, lastChangeBlock)
+        );
+    }
+
+    function setUpDefaultBalancerPool(IERC20[] memory tokens, uint256[] memory balances, uint256[] memory weights)
+        internal
+    {
+        registerPoolOnVault();
+        registerTokensAndBalancesOnVault(tokens, balances);
+        vm.mockCallRevert(address(balancerVault), hex"", abi.encode("Called unexpected function on mock vault"));
+
+        vm.mockCall(address(pool), abi.encodeCall(IWeightedPool.getNormalizedWeights, ()), abi.encode(weights));
+        vm.mockCallRevert(address(pool), hex"", abi.encode("Called unexpected function on mock pool"));
+    }
+
+    function getDefaultData() internal view returns (bytes memory data) {
+        return abi.encode(BalancerWeightedPoolPriceOracle.Data(DEFAULT_POOL_ID));
+    }
+}

--- a/test/oracles/BalancerWeightedPoolPriceOracle.sol
+++ b/test/oracles/BalancerWeightedPoolPriceOracle.sol
@@ -19,8 +19,8 @@ contract BalancerWeightedPoolPriceOracleTest is Test {
     // Technically, the first 20 bytes should be the pool address.
     // However, this property is not relied on by the Balancer price oracle.
     bytes32 private DEFAULT_POOL_ID = keccak256("Default Balancer pool id");
-    IWeightedPool internal pool = IWeightedPool(Utils.addressFromString("Balancer vault"));
-    IVault internal balancerVault = IVault(Utils.addressFromString("Balancer pool"));
+    IWeightedPool internal pool = IWeightedPool(Utils.addressFromString("Balancer pool"));
+    IVault internal balancerVault = IVault(Utils.addressFromString("Balancer vault"));
     BalancerWeightedPoolPriceOracle internal oracle;
 
     function setUp() public {

--- a/test/oracles/BalancerWeightedPoolPriceOracle/OutputByteReduction.sol
+++ b/test/oracles/BalancerWeightedPoolPriceOracle/OutputByteReduction.sol
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import "forge-std/Test.sol";
+
+import {Utils} from "test/libraries/Utils.sol";
+import {BalancerWeightedPoolPriceOracle, IVault} from "src/oracles/BalancerWeightedPoolPriceOracle.sol";
+
+contract OutputByteReductionTest is Test {
+    WrapperBalancerWeightedPoolPriceOracle internal oracle;
+    uint256 internal tolerance;
+
+    function setUp() public {
+        oracle = new WrapperBalancerWeightedPoolPriceOracle();
+        tolerance = oracle.tolerance();
+    }
+
+    function testReducesAmount() public {
+        (uint256 out1, uint256 out2) = oracle.reducer(1 << (128 + 42), 1 << (128 - 24));
+        assertEq(out1, 1 << 128);
+        assertEq(out2, 1 << (128 - 24 - 42));
+    }
+
+    function testReducesAmountWhenSecondLarger() public {
+        (uint256 out1, uint256 out2) = oracle.reducer(1 << (128 - 24), 1 << (128 + 42));
+        assertEq(out1, 1 << (128 - 24 - 42));
+        assertEq(out2, 1 << 128);
+    }
+
+    function testReducesAmountExplicitBytes() public {
+        // 128 bytes = 16 bytes.
+        //                kept (16 bytes)                 cut off
+        // Ruler:       |------------------------------||xxxxxxxxxxxxxxxxxxxxxxxxxxx|
+        uint256 in1 = 0xf123456789012345678901234567890123456789012345678901234567890;
+        uint256 ou1 = 0xf1234567890123456789012345678901;
+        // From ruler above:                  |xxxxxxxxxxxxxxxxxxxxxxxxxxx|
+        uint256 in2 = 0xf98765432109876543210987654321098765432109876543210;
+        uint256 ou2 = 0xf987654321098765432109;
+        (uint256 out1, uint256 out2) = oracle.reducer(in1, in2);
+        assertEq(out1, ou1);
+        assertEq(out2, ou2);
+    }
+
+    function testReducesAmountRoundingMaxUp() public {
+        (uint256 out1, uint256 out2) = oracle.reducer((1 << (128 + 42)) + 1, 1 << (128 - 24));
+        assertEq(out1, (1 << (128 - 1)));
+        assertEq(out2, 1 << (128 - 24 - 42 - 1));
+    }
+
+    function testReturnsInputIfAmountsAreSmall() public {
+        uint256 in1 = 1 << 128;
+        uint256 in2 = in1 - 1;
+        (uint256 out1, uint256 out2) = oracle.reducer(in1, in2);
+        assertEq(out1, in1);
+        assertEq(out2, in2);
+        // One unit more and the test would fail
+        in1 = in1 + 1;
+        (out1, out2) = oracle.reducer(in1, in2);
+        assertFalse(out1 == in1);
+        assertFalse(out2 == in2);
+    }
+
+    function testReturnsInputIfMinBelowTolerance() public {
+        uint256 in1 = (1 << (tolerance + 1)) - 1;
+        uint256 in2 = type(uint256).max;
+        (uint256 out1, uint256 out2) = oracle.reducer(in1, in2);
+        assertEq(out1, in1);
+        assertEq(out2, in2);
+        // One unit more and the test would fail
+        in1 = in1 + 1;
+        (out1, out2) = oracle.reducer(in1, in2);
+        assertFalse(out1 == in1);
+        assertFalse(out2 == in2);
+    }
+
+    function testCapsReductionIfMinAmountWouldGoBelowTolerance() public {
+        (uint256 out1, uint256 out2) = oracle.reducer(1 << (tolerance + 42), 1 << 255);
+        assertEq(out1, 1 << tolerance);
+        assertEq(out2, 1 << (255 - 42));
+    }
+
+    function testToleranceIsLessThanOneBasePoint() public {
+        assertTrue((1 << tolerance) > 10000);
+    }
+}
+
+// Wrapper that makes the function `reduceOutputBytes` public
+contract WrapperBalancerWeightedPoolPriceOracle is BalancerWeightedPoolPriceOracle {
+    uint256 public tolerance = TOLERANCE;
+
+    // The Balancer address is irrelevant
+    constructor() BalancerWeightedPoolPriceOracle(IVault(address(0))) {}
+
+    function reducer(uint256 num1, uint256 num2) public pure returns (uint256, uint256) {
+        return reduceOutputBytes(num1, num2);
+    }
+}

--- a/test/oracles/BalancerWeightedPoolPriceOracle/Parameters.sol
+++ b/test/oracles/BalancerWeightedPoolPriceOracle/Parameters.sol
@@ -1,0 +1,20 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import "forge-std/Test.sol";
+
+import {Utils} from "test/libraries/Utils.sol";
+import {BalancerWeightedPoolPriceOracle, IVault} from "src/oracles/BalancerWeightedPoolPriceOracle.sol";
+
+contract BalancerWeightedPoolPriceOracleTest is Test {
+    IVault internal balancerVault;
+    BalancerWeightedPoolPriceOracle internal oracle;
+
+    function setUp() public {
+        oracle = new BalancerWeightedPoolPriceOracle(balancerVault);
+    }
+
+    function testVaultAddress() public {
+        assertEq(address(oracle.vault()), address(balancerVault));
+    }
+}

--- a/test/oracles/UniswapV2PriceOracle.sol
+++ b/test/oracles/UniswapV2PriceOracle.sol
@@ -3,8 +3,8 @@ pragma solidity >=0.8.0 <0.9.0;
 
 import "forge-std/Test.sol";
 
-import {Utils} from "./libraries/Utils.sol";
-import {UniswapV2PriceOracle, IUniswapV2Pair} from "../src/oracles/UniswapV2PriceOracle.sol";
+import {Utils} from "test/libraries/Utils.sol";
+import {UniswapV2PriceOracle, IUniswapV2Pair} from "src/oracles/UniswapV2PriceOracle.sol";
 
 contract UniswapV2PriceOracleTest is Test {
     address private USDC = Utils.addressFromString("USDC");


### PR DESCRIPTION
Adds a new price oracle for Balancer weighted pools.

Some notes:
- It should support all weighted pools from v1 to v4 since they all support the interface used in this PR.
- Unfortunately, it also returns a price for other pool types apart from weighted pools (e.g., managed pools). Determining from an id its pool type is difficult and would require checking the contract code for the old weighted pool versions and on-chain JSON manipulation for newer pool versions. To avoid the complexity (and corresponding gas cost) this isn't done and we trust the user to verify that the pool is a Balancer weighted pool.  

### How to test

New unit tests.