### PR TITLE
Add order commitment check on verification

### DIFF
--- a/script/libraries/Utils.sol
+++ b/script/libraries/Utils.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import {Script} from "forge-std/Script.sol";
+
+abstract contract Utils is Script {
+    function addressEnvOrDefault(string memory envName, address defaultAddr) internal view returns (address) {
+        try vm.envAddress(envName) returns (address env) {
+            return env;
+        } catch {
+            return defaultAddr;
+        }
+    }
+
+    function assertHasCode(address a, string memory context) internal view {
+        require(a.code.length > 0, context);
+    }
+}

--- a/script/single-deployment/BalancerWeightedPoolPriceOracle.s.sol
+++ b/script/single-deployment/BalancerWeightedPoolPriceOracle.s.sol
@@ -3,24 +3,27 @@ pragma solidity >=0.8.0 <0.9.0;
 
 import {Script, console} from "forge-std/Script.sol";
 
+import {Utils} from "../libraries/Utils.sol";
+
 import {BalancerWeightedPoolPriceOracle, IVault} from "src/oracles/BalancerWeightedPoolPriceOracle.sol";
 
-contract DeployBalancerWeightedPoolPriceOracle is Script {
-    string constant balancerVaultEnv = "BALANCER_VAULT";
+contract DeployBalancerWeightedPoolPriceOracle is Script, Utils {
+    // Balancer uses the same address on each supported chain until now:
+    // https://docs.balancer.fi/reference/contracts/deployment-addresses/mainnet.html
+    // Chains: Arbitrum, Avalanche, Base, Gnosis, Goerli, Mainnet, Optimism,
+    // Polygon, Sepolia, Zkevm
+    address internal constant DEFAULT_BALANCER_VAULT = 0xBA12222222228d8Ba445958a75a0704d566BF2C8;
     IVault internal vault;
 
     constructor() {
-        try vm.envAddress(balancerVaultEnv) returns (address vault_) {
-            vault = IVault(vault_);
-        } catch {
-            vault = defaultBalancerVault();
-        }
-        console.log("Balancer vault at %s.", address(vault));
+        address vaultAddress = addressEnvOrDefault("BALANCER_VAULT", DEFAULT_BALANCER_VAULT);
+        console.log("Balancer vault at %s.", vaultAddress);
         // We assume that if there's code at that address, then it's a Balancer
         // vault deployment. This isn't guaranteed because they don't use
         // deterministic addresses and in theory there could be any contract
         // there.
-        require(address(vault).code.length > 0, "no code at expected Balancer vault");
+        assertHasCode(vaultAddress, "no code at expected Balancer vault");
+        vault = IVault(vaultAddress);
     }
 
     function run() public virtual {
@@ -30,13 +33,5 @@ contract DeployBalancerWeightedPoolPriceOracle is Script {
     function deployBalancerWeightedPoolPriceOracle() internal returns (BalancerWeightedPoolPriceOracle) {
         vm.broadcast();
         return new BalancerWeightedPoolPriceOracle(vault);
-    }
-
-    function defaultBalancerVault() internal pure returns (IVault) {
-        // Balancer uses the same address on each supported chain until now:
-        // https://docs.balancer.fi/reference/contracts/deployment-addresses/mainnet.html
-        // Chains: Arbitrum, Avalanche, Base, Gnosis, Goerli, Mainnet, Optimism,
-        // Polygon, Sepolia, Zkevm
-        return IVault(0xBA12222222228d8Ba445958a75a0704d566BF2C8);
     }
 }

--- a/script/single-deployment/ConstantProduct.s.sol
+++ b/script/single-deployment/ConstantProduct.s.sol
@@ -1,17 +1,28 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import {Script} from "forge-std/Script.sol";
+import {Script, console} from "forge-std/Script.sol";
+
+import {Utils} from "../libraries/Utils.sol";
 
 import {ConstantProduct} from "src/ConstantProduct.sol";
 
-contract DeployConstantProduct is Script {
+contract DeployConstantProduct is Script, Utils {
+    address internal constant DEFAULT_SETTLEMENT_CONTRACT = 0x9008D19f58AAbD9eD0D60971565AA8510560ab41;
+    address internal solutionSettler;
+
+    constructor() {
+        solutionSettler = addressEnvOrDefault("SETTLEMENT_CONTRACT", DEFAULT_SETTLEMENT_CONTRACT);
+        console.log("Settlement contract at %s.", solutionSettler);
+        assertHasCode(solutionSettler, "no code at expected settlement contract");
+    }
+
     function run() public virtual {
         deployConstantProduct();
     }
 
     function deployConstantProduct() internal returns (ConstantProduct) {
         vm.broadcast();
-        return new ConstantProduct();
+        return new ConstantProduct(solutionSettler);
     }
 }

--- a/src/ConstantProduct.sol
+++ b/src/ConstantProduct.sol
@@ -73,6 +73,19 @@ contract ConstantProduct is IConditionalOrderGenerator {
      * context.
      */
     error CommitOutsideOfSettlement();
+    /**
+     * @notice Error thrown when a solver tries to settle an AMM order on CoW
+     * Protocol whose hash doesn't match the one that has been committed to in
+     * the `commitment` mapping.
+     */
+    error OrderDoesNotMatchCommitmentHash();
+    /**
+     * @notice If an AMM order is settled and the AMM committment is set to
+     * empty, then that order must match the output of `getTradeableOrder`.
+     * This error is thrown when some of the parameters don't match the expected
+     * ones.
+     */
+    error OrderDoesNotMatchDefaultTradeableOrder();
 
     /**
      * @param _solutionSettler The CoW Protocol contract used to settle user
@@ -337,11 +350,11 @@ contract ConstantProduct is IConditionalOrderGenerator {
         bytes32 committedOrderHash = commitment[owner];
         if (orderHash != committedOrderHash) {
             if (committedOrderHash != EMPTY_COMMITMENT) {
-                revert IConditionalOrder.OrderNotValid("commitment not matching");
+                revert OrderDoesNotMatchCommitmentHash();
             }
             GPv2Order.Data memory computedOrder = _getTradeableOrder(owner, staticInput);
             if (!matchFreeOrderParams(order, computedOrder)) {
-                revert IConditionalOrder.OrderNotValid("getTradeableOrder not matching");
+                revert OrderDoesNotMatchDefaultTradeableOrder();
             }
         }
     }

--- a/src/ConstantProduct.sol
+++ b/src/ConstantProduct.sol
@@ -23,8 +23,6 @@ import {IWatchtowerCustomErrors} from "./interfaces/IWatchtowerCustomErrors.sol"
  * Order creation and execution is based on the Composable CoW base contracts.
  */
 contract ConstantProduct is IConditionalOrderGenerator {
-    uint32 public constant MAX_ORDER_DURATION = 5 * 60;
-
     /// All data used by an order to validate the AMM conditions.
     struct Data {
         /// The first of the tokens traded by this AMM.
@@ -43,6 +41,61 @@ contract ConstantProduct is IConditionalOrderGenerator {
         /// The app data that must be used in the order.
         /// See `GPv2Order.Data` for more information on the app data.
         bytes32 appData;
+    }
+
+    /**
+     * @notice The largest possible duration of any AMM order, starting from the
+     * current block timestamp.
+     */
+    uint32 public constant MAX_ORDER_DURATION = 5 * 60;
+    /**
+     * @notice The value representing the absence of a commitment. It signifies
+     * that the AMM will enforce that the order matches the order obtained from
+     * calling `getTradeableOrder`.
+     */
+    bytes32 public constant EMPTY_COMMITMENT = bytes32(0);
+    /**
+     * @notice The address of the CoW Protocol settlement contract. It is the
+     * only address that can set commitments.
+     */
+    address public immutable solutionSettler;
+    /**
+     * @notice It associates every order owner to the only order hash that can
+     * be validated by calling `verify`. The hash corresponding to the constant
+     * `EMPTY_COMMITMENT` has special semantics, discussed in the related
+     * documentation.
+     */
+    mapping(address => bytes32) public commitment;
+
+    /**
+     * @notice The `commit` function can only be called inside a CoW Swap
+     * settlement. This error is thrown when the function is called from another
+     * context.
+     */
+    error CommitOutsideOfSettlement();
+
+    /**
+     * @param _solutionSettler The CoW Protocol contract used to settle user
+     * orders on the current chain.
+     */
+    constructor(address _solutionSettler) {
+        solutionSettler = _solutionSettler;
+    }
+
+    /**
+     * @notice Restricts a specific AMM to being able to trade only the order
+     * with the specified hash.
+     * @dev The commitment is used to enforce that exactly one AMM order is
+     * valid when a CoW Protocol batch is settled.
+     * @param owner the commitment applies to orders created by this address.
+     * @param orderHash the order hash that will be enforced by the order
+     * verification function.
+     */
+    function commit(address owner, bytes32 orderHash) public {
+        if (msg.sender != solutionSettler) {
+            revert CommitOutsideOfSettlement();
+        }
+        commitment[owner] = orderHash;
     }
 
     /**
@@ -65,8 +118,6 @@ contract ConstantProduct is IConditionalOrderGenerator {
      * parameters that are required for order creation. Compared to implementing
      * the logic inside the original function, it frees up some stack slots and
      * reduces "stack too deep" issues.
-     * @dev We are not interested in the gas efficiency of this function because
-     * it is not supposed to be called by a call in the blockchain.
      * @param owner the contract who is the owner of the order
      * @param staticInput the static input for all discrete orders cut from this
      * conditional order
@@ -156,14 +207,14 @@ contract ConstantProduct is IConditionalOrderGenerator {
     function verify(
         address owner,
         address,
-        bytes32,
+        bytes32 orderHash,
         bytes32,
         bytes32,
         bytes calldata staticInput,
         bytes calldata,
         GPv2Order.Data calldata order
     ) external view override {
-        _verify(owner, staticInput, order);
+        _verify(owner, orderHash, staticInput, order);
     }
 
     /**
@@ -172,11 +223,17 @@ contract ConstantProduct is IConditionalOrderGenerator {
      * `verify`, it frees up some stack slots and reduces "stack too deep"
      * issues.
      * @param owner the contract who is the owner of the order
+     * @param orderHash the hash of the current order as defined by the
+     * `GPv2Order` library.
      * @param staticInput the static input for all discrete orders cut from this
      * conditional order
      * @param order `GPv2Order.Data` of a discrete order to be verified.
      */
-    function _verify(address owner, bytes calldata staticInput, GPv2Order.Data calldata order) internal view {
+    function _verify(address owner, bytes32 orderHash, bytes calldata staticInput, GPv2Order.Data calldata order)
+        internal
+        view
+    {
+        requireMatchingCommitment(owner, orderHash, staticInput, order);
         ConstantProduct.Data memory data = abi.decode(staticInput, (Data));
 
         IERC20 sellToken = data.token0;
@@ -221,8 +278,8 @@ contract ConstantProduct is IConditionalOrderGenerator {
         }
 
         // No checks on:
-        //bytes32 kind;
-        //bool partiallyFillable;
+        // - kind
+        // - partiallyFillable
     }
 
     /**
@@ -258,5 +315,67 @@ contract ConstantProduct is IConditionalOrderGenerator {
      */
     function revertPollAtNextBucket(string memory message) internal view {
         revert IWatchtowerCustomErrors.PollTryAtBlock(block.number + 1, message);
+    }
+
+    /**
+     * @notice This function triggers a revert if either (1) the order hash does
+     * not match the current commitment of the owner, or (2) in the case of a
+     * commitment to `EMPTY_COMMITMENT`, the non-constant parameters of the
+     * order from `getTradeableOrder` don't match those of the input order.
+     * @param owner the contract that owns the order
+     * @param orderHash the hash of the current order as defined by the
+     * `GPv2Order` library.
+     * @param staticInput the static input for all discrete orders cut from this
+     * conditional order
+     * @param order `GPv2Order.Data` of a discrete order to be verified
+     */
+    function requireMatchingCommitment(
+        address owner,
+        bytes32 orderHash,
+        bytes calldata staticInput,
+        GPv2Order.Data calldata order
+    ) internal view {
+        bytes32 committedOrderHash = commitment[owner];
+        if (orderHash != committedOrderHash) {
+            if (committedOrderHash != EMPTY_COMMITMENT) {
+                revert IConditionalOrder.OrderNotValid("commitment not matching");
+            }
+            GPv2Order.Data memory computedOrder = _getTradeableOrder(owner, staticInput);
+            if (!matchFreeOrderParams(order, computedOrder)) {
+                revert IConditionalOrder.OrderNotValid("getTradeableOrder not matching");
+            }
+        }
+    }
+
+    /**
+     * @notice Check if the parameters of the two input orders are the same,
+     * with the exception of those parameters that have a single possible value
+     * that passes the validation of `verify`.
+     * @param lhs a CoW Swap order
+     * @param rhs another CoW Swap order
+     * @return true if the order parameters match, false otherwise
+     */
+    function matchFreeOrderParams(GPv2Order.Data calldata lhs, GPv2Order.Data memory rhs)
+        internal
+        pure
+        returns (bool)
+    {
+        bool sameSellToken = lhs.sellToken == rhs.sellToken;
+        bool sameBuyToken = lhs.buyToken == rhs.buyToken;
+        bool sameSellAmount = lhs.sellAmount == rhs.sellAmount;
+        bool sameBuyAmount = lhs.buyAmount == rhs.buyAmount;
+        bool sameValidTo = lhs.validTo == rhs.validTo;
+        bool sameKind = lhs.kind == rhs.kind;
+        bool samePartiallyFillable = lhs.partiallyFillable == rhs.partiallyFillable;
+
+        // The following parameters are untested:
+        // - receiver
+        // - appData
+        // - feeAmount
+        // - sellTokenBalance
+        // - buyTokenBalance
+
+        return sameSellToken && sameBuyToken && sameSellAmount && sameBuyAmount && sameValidTo && sameKind
+            && samePartiallyFillable;
     }
 }

--- a/test/ConstantProduct.t.sol
+++ b/test/ConstantProduct.t.sol
@@ -4,5 +4,6 @@ pragma solidity ^0.8.13;
 import {VerifyTest} from "./ConstantProduct/VerifyTest.sol";
 import {GetTradeableOrderTest} from "./ConstantProduct/GetTradeableOrderTest.sol";
 import {CommitTest} from "./ConstantProduct/CommitTest.sol";
+import {DeploymentParamsTest} from "./ConstantProduct/DeploymentParamsTest.sol";
 
-contract ConstantProductTest is VerifyTest, GetTradeableOrderTest, CommitTest {}
+contract ConstantProductTest is VerifyTest, GetTradeableOrderTest, CommitTest, DeploymentParamsTest {}

--- a/test/ConstantProduct.t.sol
+++ b/test/ConstantProduct.t.sol
@@ -3,5 +3,6 @@ pragma solidity ^0.8.13;
 
 import {VerifyTest} from "./ConstantProduct/VerifyTest.sol";
 import {GetTradeableOrderTest} from "./ConstantProduct/GetTradeableOrderTest.sol";
+import {CommitTest} from "./ConstantProduct/CommitTest.sol";
 
-contract ConstantProductTest is VerifyTest, GetTradeableOrderTest {}
+contract ConstantProductTest is VerifyTest, GetTradeableOrderTest, CommitTest {}

--- a/test/ConstantProduct/CommitTest.sol
+++ b/test/ConstantProduct/CommitTest.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import {Utils} from "test/libraries/Utils.sol";
+import {ConstantProductTestHarness, ConstantProduct} from "./ConstantProductTestHarness.sol";
+
+abstract contract CommitTest is ConstantProductTestHarness {
+    function testSolutionSettlerCanSetAnyCommit() public {
+        vm.prank(solutionSettler);
+        constantProduct.commit(
+            0x1337133713371337133713371337133713371337,
+            0x4242424242424242424242424242424242424242424242424242424242424242
+        );
+    }
+
+    function testCommitIsPermissioned() public {
+        vm.prank(Utils.addressFromString("some random address"));
+        vm.expectRevert(abi.encodeWithSelector(ConstantProduct.CommitOutsideOfSettlement.selector));
+        constantProduct.commit(
+            0x1337133713371337133713371337133713371337,
+            0x4242424242424242424242424242424242424242424242424242424242424242
+        );
+    }
+
+    function testCommittingSetsCommitmentInMapping() public {
+        address addr = 0x1337133713371337133713371337133713371337;
+        bytes32 commitment = 0x4242424242424242424242424242424242424242424242424242424242424242;
+        assertEq(constantProduct.commitment(addr), bytes32(0));
+        vm.prank(solutionSettler);
+        constantProduct.commit(addr, commitment);
+        assertEq(constantProduct.commitment(addr), commitment);
+    }
+}

--- a/test/ConstantProduct/ConstantProductTestHarness.sol
+++ b/test/ConstantProduct/ConstantProductTestHarness.sol
@@ -16,7 +16,7 @@ abstract contract ConstantProductTestHarness is BaseComposableCoWTest {
     bytes32 private DEFAULT_APPDATA = keccak256(bytes("unit test"));
     bytes32 private DEFAULT_COMMITMENT = keccak256(bytes("order hash"));
 
-    address internal solutionSettler = Utils.addressFromString("settlment contract");
+    address internal solutionSettler = Utils.addressFromString("settlement contract");
     ConstantProduct internal constantProduct;
     UniswapV2PriceOracle internal uniswapV2PriceOracle;
 

--- a/test/ConstantProduct/DeploymentParamsTest.sol
+++ b/test/ConstantProduct/DeploymentParamsTest.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import {Utils} from "test/libraries/Utils.sol";
+import {ConstantProductTestHarness, ConstantProduct} from "./ConstantProductTestHarness.sol";
+
+abstract contract DeploymentParamsTest is ConstantProductTestHarness {
+    function testSetsSolutionSettler() public {
+        require(solutionSettler != address(0), "test should use a nonzero address");
+        ConstantProduct constantProduct = new ConstantProduct(solutionSettler);
+        assertEq(constantProduct.solutionSettler(), solutionSettler);
+    }
+}

--- a/test/ConstantProduct/VerifyTest.sol
+++ b/test/ConstantProduct/VerifyTest.sol
@@ -3,5 +3,6 @@ pragma solidity ^0.8.13;
 
 import {ValidateOrderParametersTest} from "./verify/ValidateOrderParametersTest.sol";
 import {ValidateAmmMath} from "./verify/ValidateAmmMath.sol";
+import {EnforceCommitmentTest} from "./verify/EnforceCommitmentTest.sol";
 
-abstract contract VerifyTest is ValidateOrderParametersTest, ValidateAmmMath {}
+abstract contract VerifyTest is ValidateOrderParametersTest, ValidateAmmMath, EnforceCommitmentTest {}

--- a/test/ConstantProduct/verify/EnforceCommitmentTest.sol
+++ b/test/ConstantProduct/verify/EnforceCommitmentTest.sol
@@ -1,0 +1,147 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import {Utils} from "test/libraries/Utils.sol";
+import {ConstantProductTestHarness} from "../ConstantProductTestHarness.sol";
+import {ConstantProduct, GPv2Order, IERC20, IConditionalOrder} from "../../../src/ConstantProduct.sol";
+
+abstract contract EnforceCommitmentTest is ConstantProductTestHarness {
+    bytes32 private orderHash = keccak256("some order hash");
+    bytes32 private orderHashAlternative = keccak256("some other order hash");
+
+    function testRevertsIfCommitDoesNotMatch() public {
+        vm.prank(solutionSettler);
+        constantProduct.commit(orderOwner, orderHash);
+        GPv2Order.Data memory order = getDefaultOrder();
+        ConstantProduct.Data memory data = getDefaultData();
+
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, "commitment not matching"));
+        verifyWrapper(orderOwner, orderHashAlternative, data, order);
+    }
+
+    function testTradeableOrderPassesValidationWithZeroCommit() public {
+        require(
+            constantProduct.commitment(orderOwner) == constantProduct.EMPTY_COMMITMENT(),
+            "test expects unset commitment"
+        );
+
+        ConstantProduct.Data memory defaultData = getDefaultData();
+        setUpDefaultReserves(orderOwner);
+        setUpDefaultReferencePairReserves(42, 1337);
+
+        GPv2Order.Data memory order = getTradeableOrderUncheckedWrapper(orderOwner, defaultData);
+        verifyWrapper(orderOwner, orderHash, defaultData, order);
+    }
+
+    function testZeroCommitRevertsForOrdersOtherThanTradeableOrder() public {
+        require(
+            constantProduct.commitment(orderOwner) == constantProduct.EMPTY_COMMITMENT(),
+            "test expects unset commitment"
+        );
+
+        ConstantProduct.Data memory defaultData = getDefaultData();
+        setUpDefaultReserves(orderOwner);
+        setUpDefaultReferencePairReserves(42, 1337);
+
+        GPv2Order.Data memory originalOrder = getTradeableOrderUncheckedWrapper(orderOwner, defaultData);
+        GPv2Order.Data memory modifiedOrder;
+
+        // All GPv2Order.Data parameters are included in this test. They are:
+        // - IERC20 sellToken;
+        // - IERC20 buyToken;
+        // - address receiver;
+        // - uint256 sellAmount;
+        // - uint256 buyAmount;
+        // - uint32 validTo;
+        // - bytes32 appData;
+        // - uint256 feeAmount;
+        // - bytes32 kind;
+        // - bool partiallyFillable;
+        // - bytes32 sellTokenBalance;
+        // - bytes32 buyTokenBalance;
+
+        modifiedOrder = deepClone(originalOrder);
+        modifiedOrder.sellToken = IERC20(Utils.addressFromString("bad sell token"));
+        vm.expectRevert(
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, "getTradeableOrder not matching")
+        );
+        verifyWrapper(orderOwner, orderHash, defaultData, modifiedOrder);
+
+        modifiedOrder = deepClone(originalOrder);
+        modifiedOrder.buyToken = IERC20(Utils.addressFromString("bad buy token"));
+        vm.expectRevert(
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, "getTradeableOrder not matching")
+        );
+        verifyWrapper(orderOwner, orderHash, defaultData, modifiedOrder);
+
+        modifiedOrder = deepClone(originalOrder);
+        modifiedOrder.receiver = Utils.addressFromString("bad receiver");
+        vm.expectRevert(
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, "receiver must be zero address")
+        );
+        verifyWrapper(orderOwner, orderHash, defaultData, modifiedOrder);
+
+        modifiedOrder = deepClone(originalOrder);
+        modifiedOrder.sellAmount = modifiedOrder.sellAmount - 1;
+        vm.expectRevert(
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, "getTradeableOrder not matching")
+        );
+        verifyWrapper(orderOwner, orderHash, defaultData, modifiedOrder);
+
+        modifiedOrder = deepClone(originalOrder);
+        modifiedOrder.buyAmount = modifiedOrder.buyAmount + 1;
+        vm.expectRevert(
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, "getTradeableOrder not matching")
+        );
+        verifyWrapper(orderOwner, orderHash, defaultData, modifiedOrder);
+
+        modifiedOrder = deepClone(originalOrder);
+        modifiedOrder.validTo = modifiedOrder.validTo - 1;
+        vm.expectRevert(
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, "getTradeableOrder not matching")
+        );
+        verifyWrapper(orderOwner, orderHash, defaultData, modifiedOrder);
+
+        modifiedOrder = deepClone(originalOrder);
+        modifiedOrder.appData = keccak256("bad app data");
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, "invalid appData"));
+        verifyWrapper(orderOwner, orderHash, defaultData, modifiedOrder);
+
+        modifiedOrder = deepClone(originalOrder);
+        modifiedOrder.feeAmount = modifiedOrder.feeAmount + 1;
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, "fee amount must be zero"));
+        verifyWrapper(orderOwner, orderHash, defaultData, modifiedOrder);
+
+        modifiedOrder = deepClone(originalOrder);
+        modifiedOrder.kind = GPv2Order.KIND_BUY;
+        vm.expectRevert(
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, "getTradeableOrder not matching")
+        );
+        verifyWrapper(orderOwner, orderHash, defaultData, modifiedOrder);
+
+        modifiedOrder = deepClone(originalOrder);
+        modifiedOrder.partiallyFillable = !modifiedOrder.partiallyFillable;
+        vm.expectRevert(
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, "getTradeableOrder not matching")
+        );
+        verifyWrapper(orderOwner, orderHash, defaultData, modifiedOrder);
+
+        modifiedOrder = deepClone(originalOrder);
+        modifiedOrder.sellTokenBalance = GPv2Order.BALANCE_EXTERNAL;
+        vm.expectRevert(
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, "sellTokenBalance must be erc20")
+        );
+        verifyWrapper(orderOwner, orderHash, defaultData, modifiedOrder);
+
+        modifiedOrder = deepClone(originalOrder);
+        modifiedOrder.buyTokenBalance = GPv2Order.BALANCE_EXTERNAL;
+        vm.expectRevert(
+            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, "buyTokenBalance must be erc20")
+        );
+        verifyWrapper(orderOwner, orderHash, defaultData, modifiedOrder);
+    }
+
+    function deepClone(GPv2Order.Data memory order) internal pure returns (GPv2Order.Data memory) {
+        return abi.decode(abi.encode(order), (GPv2Order.Data));
+    }
+}

--- a/test/ConstantProduct/verify/EnforceCommitmentTest.sol
+++ b/test/ConstantProduct/verify/EnforceCommitmentTest.sol
@@ -15,7 +15,7 @@ abstract contract EnforceCommitmentTest is ConstantProductTestHarness {
         GPv2Order.Data memory order = getDefaultOrder();
         ConstantProduct.Data memory data = getDefaultData();
 
-        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, "commitment not matching"));
+        vm.expectRevert(abi.encodeWithSelector(ConstantProduct.OrderDoesNotMatchCommitmentHash.selector));
         verifyWrapper(orderOwner, orderHashAlternative, data, order);
     }
 
@@ -62,16 +62,12 @@ abstract contract EnforceCommitmentTest is ConstantProductTestHarness {
 
         modifiedOrder = deepClone(originalOrder);
         modifiedOrder.sellToken = IERC20(Utils.addressFromString("bad sell token"));
-        vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, "getTradeableOrder not matching")
-        );
+        vm.expectRevert(abi.encodeWithSelector(ConstantProduct.OrderDoesNotMatchDefaultTradeableOrder.selector));
         verifyWrapper(orderOwner, orderHash, defaultData, modifiedOrder);
 
         modifiedOrder = deepClone(originalOrder);
         modifiedOrder.buyToken = IERC20(Utils.addressFromString("bad buy token"));
-        vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, "getTradeableOrder not matching")
-        );
+        vm.expectRevert(abi.encodeWithSelector(ConstantProduct.OrderDoesNotMatchDefaultTradeableOrder.selector));
         verifyWrapper(orderOwner, orderHash, defaultData, modifiedOrder);
 
         modifiedOrder = deepClone(originalOrder);
@@ -83,23 +79,17 @@ abstract contract EnforceCommitmentTest is ConstantProductTestHarness {
 
         modifiedOrder = deepClone(originalOrder);
         modifiedOrder.sellAmount = modifiedOrder.sellAmount - 1;
-        vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, "getTradeableOrder not matching")
-        );
+        vm.expectRevert(abi.encodeWithSelector(ConstantProduct.OrderDoesNotMatchDefaultTradeableOrder.selector));
         verifyWrapper(orderOwner, orderHash, defaultData, modifiedOrder);
 
         modifiedOrder = deepClone(originalOrder);
         modifiedOrder.buyAmount = modifiedOrder.buyAmount + 1;
-        vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, "getTradeableOrder not matching")
-        );
+        vm.expectRevert(abi.encodeWithSelector(ConstantProduct.OrderDoesNotMatchDefaultTradeableOrder.selector));
         verifyWrapper(orderOwner, orderHash, defaultData, modifiedOrder);
 
         modifiedOrder = deepClone(originalOrder);
         modifiedOrder.validTo = modifiedOrder.validTo - 1;
-        vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, "getTradeableOrder not matching")
-        );
+        vm.expectRevert(abi.encodeWithSelector(ConstantProduct.OrderDoesNotMatchDefaultTradeableOrder.selector));
         verifyWrapper(orderOwner, orderHash, defaultData, modifiedOrder);
 
         modifiedOrder = deepClone(originalOrder);
@@ -114,16 +104,12 @@ abstract contract EnforceCommitmentTest is ConstantProductTestHarness {
 
         modifiedOrder = deepClone(originalOrder);
         modifiedOrder.kind = GPv2Order.KIND_BUY;
-        vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, "getTradeableOrder not matching")
-        );
+        vm.expectRevert(abi.encodeWithSelector(ConstantProduct.OrderDoesNotMatchDefaultTradeableOrder.selector));
         verifyWrapper(orderOwner, orderHash, defaultData, modifiedOrder);
 
         modifiedOrder = deepClone(originalOrder);
         modifiedOrder.partiallyFillable = !modifiedOrder.partiallyFillable;
-        vm.expectRevert(
-            abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, "getTradeableOrder not matching")
-        );
+        vm.expectRevert(abi.encodeWithSelector(ConstantProduct.OrderDoesNotMatchDefaultTradeableOrder.selector));
         verifyWrapper(orderOwner, orderHash, defaultData, modifiedOrder);
 
         modifiedOrder = deepClone(originalOrder);

--- a/test/ConstantProduct/verify/ValidateAmmMath.sol
+++ b/test/ConstantProduct/verify/ValidateAmmMath.sol
@@ -30,6 +30,7 @@ abstract contract ValidateAmmMath is ConstantProductTestHarness {
         internal
         returns (ConstantProduct.Data memory data, GPv2Order.Data memory order)
     {
+        setUpDefaultCommitment(orderOwner);
         setUpAmmWithReserves(amountToken0, amountToken1);
         order = getDefaultOrder();
         order.sellToken = IERC20(pair.token0());

--- a/test/ConstantProduct/verify/ValidateOrderParametersTest.sol
+++ b/test/ConstantProduct/verify/ValidateOrderParametersTest.sol
@@ -12,6 +12,7 @@ abstract contract ValidateOrderParametersTest is ConstantProductTestHarness {
     {
         defaultData = setUpDefaultData();
         setUpDefaultReserves(orderOwner);
+        setUpDefaultCommitment(orderOwner);
         defaultOrder = getDefaultOrder();
     }
 

--- a/test/script/DeployAllContracts.t.sol
+++ b/test/script/DeployAllContracts.t.sol
@@ -4,13 +4,15 @@ pragma solidity >=0.8.0 <0.9.0;
 import {Test} from "forge-std/Test.sol";
 
 import {BalancerSetUp} from "./single-deployment/balancer/BalancerSetUp.sol";
+import {CowProtocolSetUp} from "./single-deployment/cow-protocol/CowProtocolSetUp.sol";
 
 import {DeployAllContracts} from "script/DeployAllContracts.s.sol";
 
-contract DeployAllContractsTest is Test, BalancerSetUp {
+contract DeployAllContractsTest is Test, BalancerSetUp, CowProtocolSetUp {
     DeployAllContracts script;
 
     function setUp() public {
+        setUpSettlementContract();
         setUpBalancerVault();
         script = new DeployAllContracts();
     }

--- a/test/script/single-deployment/DeployConstantProduct.t.sol
+++ b/test/script/single-deployment/DeployConstantProduct.t.sol
@@ -3,12 +3,15 @@ pragma solidity >=0.8.0 <0.9.0;
 
 import {Test} from "forge-std/Test.sol";
 
+import {CowProtocolSetUp} from "./cow-protocol/CowProtocolSetUp.sol";
+
 import {DeployConstantProduct} from "script/single-deployment/ConstantProduct.s.sol";
 
-contract DeployConstantProductTest is Test {
+contract DeployConstantProductTest is Test, CowProtocolSetUp {
     DeployConstantProduct script;
 
     function setUp() public {
+        setUpSettlementContract();
         script = new DeployConstantProduct();
     }
 

--- a/test/script/single-deployment/cow-protocol/CowProtocolSetUp.sol
+++ b/test/script/single-deployment/cow-protocol/CowProtocolSetUp.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity >=0.8.0 <0.9.0;
+
+import {Test} from "forge-std/Test.sol";
+
+abstract contract CowProtocolSetUp is Test {
+    function setUpSettlementContract() internal {
+        vm.etch(0x9008D19f58AAbD9eD0D60971565AA8510560ab41, hex"1337");
+    }
+}


### PR DESCRIPTION
We want to have at most a single valid AMM order on any batch while at the same time providing the flexibility to solvers to create arbitrary orders within the constraints of the AMM function.

This PR enforces this by a commitment mechanism.
If no commitment is set, the verification function assumes that there is an implicit commitment to the order obtained from `getTradeableOrder` and it checks that the input order parameters match.
Any other previously valid order `o` can be settled in a batch as follows.
1. The solver calls `commit(ammAddress, o.hash())` in a pre-interaction.
2. As long as the order passes the AMM checks, signature verification also passes.
3. The solver calls `commit(ammAddress, EMPTY_COMMITMENT)` in a post-interaction to unset the commitment and get back some gas as refund.

It would be really nice to use `TSTORE` to avoid point 3 and to make this process much cheaper but we're a month too early.

Drawbacks of these changes: calling `getTradeableOrder` or committing means an increased gas cost when settling the order.

### To do (in another PR)

Update the docs to explain the role of commitments and their intended usage.

### How to test

Existing and new unit tests. [Here](https://dashboard.tenderly.co/tx/sepolia/0x698a6a232a9cf56ce77909e01630bdb75f128783cdd2166536cc675e10fd957f/gas-usage) is a test order for this code.
You can get a feeling for the gas cost by resimulating without access list. The [simulation](https://dashboard.tenderly.co/fedgiac/one-off-simulations/simulator/8a6adeae-6350-4647-bb69-4f4500f5d72d/gas-usage) highlights that the cost of the extra call to perform the extra checks is about 31k gas.

I also tested that, assuming a commit is set and an order is possible, the watchtower doesn't stop indexing the order. (See internal logs [here](https://production-6de61f.kb.eu-central-1.aws.cloud.es.io/app/r/s/TLDxc).) It does become noisy however.