### PR TITLE
chore: vendored openzepplin safeerc20 and address for safe

### DIFF
--- a/src/libraries/SafeModuleAddress.sol
+++ b/src/libraries/SafeModuleAddress.sol
@@ -1,18 +1,18 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: GPL-3.0
 
-// Vendored from OpenZeppelin contracts with minor modifications:
+// Logic mostly ported from OpenZeppelin contracts for use in the
+// context of a Safe Multisig. Highlights:
 // - Removed all functions except `functionCall` and `functionCallWithValue`
 // - Functions modified to accept a `ISafe` as the first argument which
 //   is the Safe used to execute the transaction.
 // - Modified `functionCallWithValue` to execute the transaction via a Safe,
 //   designed to be called from a module.
 // - Added imports for Safe related contracts.
-// - Added import for canonical Address library.
 // <https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.0.1/contracts/utils/Address.sol>
 
 // OpenZeppelin Contracts (last updated v5.0.0) (utils/Address.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.8.0 <0.9.0;
 
 import {Safe, Enum} from "lib/composable-cow/lib/safe/contracts/Safe.sol";
 

--- a/src/libraries/SafeModuleAddress.sol
+++ b/src/libraries/SafeModuleAddress.sol
@@ -1,0 +1,119 @@
+// SPDX-License-Identifier: MIT
+
+// Vendored from OpenZeppelin contracts with minor modifications:
+// - Removed all functions except `functionCall` and `functionCallWithValue`
+// - Functions modified to accept a `ISafe` as the first argument which
+//   is the Safe used to execute the transaction.
+// - Modified `functionCallWithValue` to execute the transaction via a Safe,
+//   designed to be called from a module.
+// - Added imports for Safe related contracts.
+// - Added import for canonical Address library.
+// <https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.0.1/contracts/utils/Address.sol>
+
+// OpenZeppelin Contracts (last updated v5.0.0) (utils/Address.sol)
+
+pragma solidity ^0.8.20;
+
+import {Safe, Enum} from "lib/composable-cow/lib/safe/contracts/Safe.sol";
+
+/**
+ * @dev Collection of functions related to the address type
+ */
+library SafeModuleAddress {
+    /**
+     * @dev The ETH balance of the account is not enough to perform the operation.
+     */
+    error AddressInsufficientBalance(address account);
+
+    /**
+     * @dev There's no code at `target` (it is not a contract).
+     */
+    error AddressEmptyCode(address target);
+
+    /**
+     * @dev A call to an address target failed. The target may have reverted.
+     */
+    error FailedInnerCall();
+
+    /**
+     * @dev Performs a Solidity function call using a low level `call`. A
+     * plain `call` is an unsafe replacement for a function call: use this
+     * function instead.
+     *
+     * If `target` reverts with a revert reason or custom error, it is bubbled
+     * up by this function (like regular Solidity function calls). However, if
+     * the call reverted with no returned reason, this function reverts with a
+     * {FailedInnerCall} error.
+     *
+     * Returns the raw returned data. To convert to the expected return value,
+     * use https://solidity.readthedocs.io/en/latest/units-and-global-variables.html?highlight=abi.decode#abi-encoding-and-decoding-functions[`abi.decode`].
+     *
+     * Requirements:
+     *
+     * - `target` must be a contract.
+     * - calling `target` with `data` must not revert.
+     */
+    function functionCall(Safe safe, address target, bytes memory data) internal returns (bytes memory) {
+        return functionCallWithValue(safe, target, data, 0);
+    }
+
+    /**
+     * @dev Same as {xref-Address-functionCall-address-bytes-}[`functionCall`],
+     * but also transferring `value` wei to `target`.
+     *
+     * Requirements:
+     *
+     * - the calling contract must have an ETH balance of at least `value`.
+     * - the called Solidity function must be `payable`.
+     */
+    function functionCallWithValue(Safe safe, address target, bytes memory data, uint256 value)
+        internal
+        returns (bytes memory)
+    {
+        if (address(safe).balance < value) {
+            revert AddressInsufficientBalance(address(safe));
+        }
+        (bool success, bytes memory returndata) =
+            safe.execTransactionFromModuleReturnData(target, value, data, Enum.Operation.Call);
+        return verifyCallResultFromTarget(target, success, returndata);
+    }
+
+    /**
+     * @dev Tool to verify that a low level call to smart-contract was successful, and reverts if the target
+     * was not a contract or bubbling up the revert reason (falling back to {FailedInnerCall}) in case of an
+     * unsuccessful call.
+     */
+    function verifyCallResultFromTarget(address target, bool success, bytes memory returndata)
+        internal
+        view
+        returns (bytes memory)
+    {
+        if (!success) {
+            _revert(returndata);
+        } else {
+            // only check if target is a contract if the call was successful and the return data is empty
+            // otherwise we already know that it was a contract
+            if (returndata.length == 0 && target.code.length == 0) {
+                revert AddressEmptyCode(target);
+            }
+            return returndata;
+        }
+    }
+
+    /**
+     * @dev Reverts with returndata if present. Otherwise reverts with {FailedInnerCall}.
+     */
+    function _revert(bytes memory returndata) private pure {
+        // Look for revert reason and bubble it up if present
+        if (returndata.length > 0) {
+            // The easiest way to bubble the revert reason is using memory via assembly
+            /// @solidity memory-safe-assembly
+            assembly {
+                let returndata_size := mload(returndata)
+                revert(add(32, returndata), returndata_size)
+            }
+        } else {
+            revert FailedInnerCall();
+        }
+    }
+}

--- a/src/libraries/SafeModuleSafeERC20.sol
+++ b/src/libraries/SafeModuleSafeERC20.sol
@@ -31,11 +31,6 @@ library SafeModuleSafeERC20 {
     error SafeERC20FailedOperation(address token);
 
     /**
-     * @dev Indicates a failed `decreaseAllowance` request.
-     */
-    error SafeERC20FailedDecreaseAllowance(address spender, uint256 currentAllowance, uint256 requestedDecrease);
-
-    /**
      * @dev Transfer `value` amount of `token` from the calling contract to `to`. If `token` returns no value,
      * non-reverting calls are assumed to be successful.
      */
@@ -49,29 +44,6 @@ library SafeModuleSafeERC20 {
      */
     function safeTransferFrom(Safe safe, IERC20 token, address from, address to, uint256 value) internal {
         _callOptionalReturn(safe, token, abi.encodeCall(token.transferFrom, (from, to, value)));
-    }
-
-    /**
-     * @dev Increase the calling contract's allowance toward `spender` by `value`. If `token` returns no value,
-     * non-reverting calls are assumed to be successful.
-     */
-    function safeIncreaseAllowance(Safe safe, IERC20 token, address spender, uint256 value) internal {
-        uint256 oldAllowance = token.allowance(address(this), spender);
-        forceApprove(safe, token, spender, oldAllowance + value);
-    }
-
-    /**
-     * @dev Decrease the calling contract's allowance toward `spender` by `requestedDecrease`. If `token` returns no
-     * value, non-reverting calls are assumed to be successful.
-     */
-    function safeDecreaseAllowance(Safe safe, IERC20 token, address spender, uint256 requestedDecrease) internal {
-        unchecked {
-            uint256 currentAllowance = token.allowance(address(this), spender);
-            if (currentAllowance < requestedDecrease) {
-                revert SafeERC20FailedDecreaseAllowance(spender, currentAllowance, requestedDecrease);
-            }
-            forceApprove(safe, token, spender, currentAllowance - requestedDecrease);
-        }
     }
 
     /**

--- a/src/libraries/SafeModuleSafeERC20.sol
+++ b/src/libraries/SafeModuleSafeERC20.sol
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: MIT
+
+// Vendored from OpenZeppelin contracts with minor modifications:
+// - Functions modified to accept an `ISafe` and `IERC20` as the first two arguments
+//   which is the Safe used to execute the transaction and the token being transferred.
+//   For executing the transaction, uses the `functionCall` function from SafeModuleAddress.sol.
+// - Added imports for Safe related contracts.
+// - Minor edits to dev comments removing `SafeERC20` references.
+// <https://github.com/OpenZeppelin/openzeppelin-contracts/blob/v5.0.1/contracts/token/ERC20/utils/SafeERC20.sol>
+
+// OpenZeppelin Contracts (last updated v5.0.0) (token/ERC20/utils/SafeERC20.sol)
+
+pragma solidity ^0.8.20;
+
+import {IERC20} from "lib/composable-cow/lib/@openzeppelin/contracts/interfaces/IERC20.sol";
+import {SafeModuleAddress} from "./SafeModuleAddress.sol";
+import {Safe, Enum} from "lib/composable-cow/lib/safe/contracts/Safe.sol";
+
+/**
+ * @title SafeModuleSafeERC20
+ * @dev Wrappers around ERC20 operations that throw on failure (when the token
+ * contract returns false). Tokens that return no value (and instead revert or
+ * throw on failure) are also supported, non-reverting calls are assumed to be
+ * successful.
+ */
+library SafeModuleSafeERC20 {
+    /**
+     * @dev An operation with an ERC20 token failed.
+     */
+    error SafeERC20FailedOperation(address token);
+
+    /**
+     * @dev Indicates a failed `decreaseAllowance` request.
+     */
+    error SafeERC20FailedDecreaseAllowance(address spender, uint256 currentAllowance, uint256 requestedDecrease);
+
+    /**
+     * @dev Transfer `value` amount of `token` from the calling contract to `to`. If `token` returns no value,
+     * non-reverting calls are assumed to be successful.
+     */
+    function safeTransfer(Safe safe, IERC20 token, address to, uint256 value) internal {
+        _callOptionalReturn(safe, token, abi.encodeCall(token.transfer, (to, value)));
+    }
+
+    /**
+     * @dev Transfer `value` amount of `token` from `from` to `to`, spending the approval given by `from` to the
+     * calling contract. If `token` returns no value, non-reverting calls are assumed to be successful.
+     */
+    function safeTransferFrom(Safe safe, IERC20 token, address from, address to, uint256 value) internal {
+        _callOptionalReturn(safe, token, abi.encodeCall(token.transferFrom, (from, to, value)));
+    }
+
+    /**
+     * @dev Increase the calling contract's allowance toward `spender` by `value`. If `token` returns no value,
+     * non-reverting calls are assumed to be successful.
+     */
+    function safeIncreaseAllowance(Safe safe, IERC20 token, address spender, uint256 value) internal {
+        uint256 oldAllowance = token.allowance(address(this), spender);
+        forceApprove(safe, token, spender, oldAllowance + value);
+    }
+
+    /**
+     * @dev Decrease the calling contract's allowance toward `spender` by `requestedDecrease`. If `token` returns no
+     * value, non-reverting calls are assumed to be successful.
+     */
+    function safeDecreaseAllowance(Safe safe, IERC20 token, address spender, uint256 requestedDecrease) internal {
+        unchecked {
+            uint256 currentAllowance = token.allowance(address(this), spender);
+            if (currentAllowance < requestedDecrease) {
+                revert SafeERC20FailedDecreaseAllowance(spender, currentAllowance, requestedDecrease);
+            }
+            forceApprove(safe, token, spender, currentAllowance - requestedDecrease);
+        }
+    }
+
+    /**
+     * @dev Set the calling contract's allowance toward `spender` to `value`. If `token` returns no value,
+     * non-reverting calls are assumed to be successful. Meant to be used with tokens that require the approval
+     * to be set to zero before setting it to a non-zero value, such as USDT.
+     */
+    function forceApprove(Safe safe, IERC20 token, address spender, uint256 value) internal {
+        bytes memory approvalCall = abi.encodeCall(token.approve, (spender, value));
+
+        if (!_callOptionalReturnBool(safe, token, approvalCall)) {
+            _callOptionalReturn(safe, token, abi.encodeCall(token.approve, (spender, 0)));
+            _callOptionalReturn(safe, token, approvalCall);
+        }
+    }
+
+    /**
+     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement
+     * on the return value: the return value is optional (but if data is returned, it must not be false).
+     * @param token The token targeted by the call.
+     * @param data The call data (encoded using abi.encode or one of its variants).
+     */
+    function _callOptionalReturn(Safe safe, IERC20 token, bytes memory data) private {
+        // We need to perform a low level call here, to bypass Solidity's return data size checking mechanism, since
+        // we're implementing it ourselves. We use {SafeModuleAddress-functionCall} to perform this call, which verifies that
+        // the target address contains contract code and also asserts for success in the low-level call.
+
+        bytes memory returndata = SafeModuleAddress.functionCall(safe, address(token), data);
+        if (returndata.length != 0 && !abi.decode(returndata, (bool))) {
+            revert SafeERC20FailedOperation(address(token));
+        }
+    }
+
+    /**
+     * @dev Imitates a Solidity high-level call (i.e. a regular function call to a contract), relaxing the requirement
+     * on the return value: the return value is optional (but if data is returned, it must not be false).
+     * @param token The token targeted by the call.
+     * @param data The call data (encoded using abi.encode or one of its variants).
+     *
+     * This is a variant of {_callOptionalReturn} that silents catches all reverts and returns a bool instead.
+     */
+    function _callOptionalReturnBool(Safe safe, IERC20 token, bytes memory data) private returns (bool) {
+        // We need to perform a low level call here, to bypass Solidity's return data size checking mechanism, since
+        // we're implementing it ourselves. We cannot use {Address-functionCall} here since this should return false
+        // and not revert is the subcall reverts.
+
+        (bool success, bytes memory returndata) =
+            safe.execTransactionFromModuleReturnData(address(token), 0, data, Enum.Operation.Call);
+        return success && (returndata.length == 0 || abi.decode(returndata, (bool))) && address(token).code.length > 0;
+    }
+}

--- a/src/libraries/SafeModuleSafeERC20.sol
+++ b/src/libraries/SafeModuleSafeERC20.sol
@@ -1,6 +1,7 @@
-// SPDX-License-Identifier: MIT
+// SPDX-License-Identifier: GPL-3.0
 
-// Vendored from OpenZeppelin contracts with minor modifications:
+// Logic mostly ported from OpenZeppelin contracts for use in the
+// context of a Safe Multisig. Highlights:
 // - Functions modified to accept an `ISafe` and `IERC20` as the first two arguments
 //   which is the Safe used to execute the transaction and the token being transferred.
 //   For executing the transaction, uses the `functionCall` function from SafeModuleAddress.sol.
@@ -10,7 +11,7 @@
 
 // OpenZeppelin Contracts (last updated v5.0.0) (token/ERC20/utils/SafeERC20.sol)
 
-pragma solidity ^0.8.20;
+pragma solidity >=0.8.0 <0.9.0;
 
 import {IERC20} from "lib/composable-cow/lib/@openzeppelin/contracts/interfaces/IERC20.sol";
 import {SafeModuleAddress} from "./SafeModuleAddress.sol";


### PR DESCRIPTION
This PR:

Vendors the `SafeERC20` and part of the `Address` library from OpenZeppelin. This is required for parsing the return data from the Safe's `execTransactionFromModule`, to facilitate some issues related to different token's support of `transferFrom` and `approve`.

While this can be worked around with other methods for the CoW AMM safe module, this is required nonetheless for the `FundingModule`, so it might as well be included.