### PR TITLE
Make trade token addresses immutable

### DIFF
--- a/script/single-deployment/ConstantProduct.s.sol
+++ b/script/single-deployment/ConstantProduct.s.sol
@@ -3,7 +3,7 @@ pragma solidity >=0.8.0 <0.9.0;
 
 import {console} from "forge-std/Script.sol";
 
-import {ConstantProduct} from "src/ConstantProduct.sol";
+import {ConstantProduct, IERC20} from "src/ConstantProduct.sol";
 
 import {EnvReader} from "script/libraries/EnvReader.sol";
 import {Utils} from "script/libraries/Utils.sol";
@@ -21,6 +21,6 @@ contract DeployConstantProduct is EnvReader, Utils {
 
     function deployConstantProduct() internal returns (ConstantProduct) {
         vm.broadcast();
-        return new ConstantProduct(solutionSettler);
+        return new ConstantProduct(solutionSettler, IERC20(vm.envAddress("TOKEN_0")), IERC20(vm.envAddress("TOKEN_1")));
     }
 }

--- a/script/single-deployment/CowAmmModule.s.sol
+++ b/script/single-deployment/CowAmmModule.s.sol
@@ -8,7 +8,7 @@ import {GPv2Settlement} from "lib/composable-cow/lib/cowprotocol/src/contracts/G
 import {ExtensibleFallbackHandler} from "lib/composable-cow/lib/safe/contracts/handler/ExtensibleFallbackHandler.sol";
 import {IConditionalOrder} from "lib/composable-cow/src/BaseConditionalOrder.sol";
 
-import {CowAmmModule} from "src/CowAmmModule.sol";
+import {CowAmmModule, IERC20} from "src/CowAmmModule.sol";
 import {EnvReader} from "script/libraries/EnvReader.sol";
 import {Utils} from "script/libraries/Utils.sol";
 
@@ -58,7 +58,9 @@ contract DeployCowAmmModule is EnvReader, Utils {
             GPv2Settlement(payable(solutionSettler)),
             ExtensibleFallbackHandler(extensibleFallbackHandler),
             ComposableCoW(composableCow),
-            IConditionalOrder(_handler)
+            IConditionalOrder(_handler),
+            IERC20(vm.envAddress("TOKEN_0")),
+            IERC20(vm.envAddress("TOKEN_1"))
         );
     }
 }

--- a/test/ConstantProduct/ConstantProductTestHarness.sol
+++ b/test/ConstantProduct/ConstantProductTestHarness.sol
@@ -24,7 +24,7 @@ abstract contract ConstantProductTestHarness is BaseComposableCoWTest {
     function setUp() public virtual override(BaseComposableCoWTest) {
         super.setUp();
 
-        constantProduct = new ConstantProduct(solutionSettler);
+        constantProduct = new ConstantProduct(solutionSettler, IERC20(USDC), IERC20(WETH));
         uniswapV2PriceOracle = new UniswapV2PriceOracle();
     }
 
@@ -39,8 +39,6 @@ abstract contract ConstantProductTestHarness is BaseComposableCoWTest {
 
     function getDefaultData() internal view returns (ConstantProduct.Data memory) {
         return ConstantProduct.Data(
-            IERC20(USDC),
-            IERC20(WETH),
             0,
             uniswapV2PriceOracle,
             abi.encode(UniswapV2PriceOracle.Data(IUniswapV2Pair(DEFAULT_PAIR))),

--- a/test/ConstantProduct/DeploymentParamsTest.sol
+++ b/test/ConstantProduct/DeploymentParamsTest.sol
@@ -1,12 +1,18 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity >=0.8.0 <0.9.0;
 
-import {ConstantProductTestHarness, ConstantProduct} from "./ConstantProductTestHarness.sol";
+import {Utils} from "test/libraries/Utils.sol";
+
+import {ConstantProductTestHarness, ConstantProduct, IERC20} from "./ConstantProductTestHarness.sol";
 
 abstract contract DeploymentParamsTest is ConstantProductTestHarness {
     function testSetsSolutionSettler() public {
-        require(solutionSettler != address(0), "test should use a nonzero address");
-        ConstantProduct constantProduct = new ConstantProduct(solutionSettler);
+        address solutionSettler = Utils.addressFromString("DeploymentParamsTest: any solution settler");
+        address token0 = Utils.addressFromString("DeploymentParamsTest: any token0");
+        address token1 = Utils.addressFromString("DeploymentParamsTest: any token1");
+        ConstantProduct constantProduct = new ConstantProduct(solutionSettler, IERC20(token0), IERC20(token1));
         assertEq(constantProduct.solutionSettler(), solutionSettler);
+        assertEq(address(constantProduct.token0()), token0);
+        assertEq(address(constantProduct.token1()), token1);
     }
 }

--- a/test/ConstantProduct/getTradeableOrder/ValidateOrderParametersTest.sol
+++ b/test/ConstantProduct/getTradeableOrder/ValidateOrderParametersTest.sol
@@ -50,7 +50,7 @@ abstract contract ValidateOrderParametersTest is ConstantProductTestHarness {
         vm.roll(currentBlock);
 
         GPv2Order.Data memory order = getTradeableOrderWrapper(orderOwner, defaultData);
-        require(order.sellToken == defaultData.token0, "test was design for token0 to be the sell token");
+        require(order.sellToken == constantProduct.token0(), "test was design for token0 to be the sell token");
         defaultData.minTradedToken0 = order.sellAmount;
         order = getTradeableOrderWrapper(orderOwner, defaultData);
         defaultData.minTradedToken0 = order.sellAmount + 1;
@@ -71,7 +71,7 @@ abstract contract ValidateOrderParametersTest is ConstantProductTestHarness {
         vm.roll(currentBlock);
 
         GPv2Order.Data memory order = getTradeableOrderWrapper(orderOwner, defaultData);
-        require(order.buyToken == defaultData.token0, "test was design for token0 to be the buy token");
+        require(order.buyToken == constantProduct.token0(), "test was design for token0 to be the buy token");
         defaultData.minTradedToken0 = order.buyAmount;
         order = getTradeableOrderWrapper(orderOwner, defaultData);
         defaultData.minTradedToken0 = order.buyAmount + 1;

--- a/test/ConstantProduct/getTradeableOrder/ValidateUniswapMath.sol
+++ b/test/ConstantProduct/getTradeableOrder/ValidateUniswapMath.sol
@@ -14,8 +14,8 @@ abstract contract ValidateUniswapMath is ConstantProductTestHarness {
         setUpDefaultReferencePairReserves(1 ether, 10 ether);
         GPv2Order.Data memory order = getTradeableOrderWrapper(orderOwner, defaultData);
 
-        assertEq(address(order.sellToken), address(defaultData.token0));
-        assertEq(address(order.buyToken), address(defaultData.token1));
+        assertEq(address(order.sellToken), address(constantProduct.token0()));
+        assertEq(address(order.buyToken), address(constantProduct.token1()));
 
         // Assert explicit amounts to see that the trade is reasonable.
         assertEq(order.sellAmount, 4.5 ether);
@@ -32,8 +32,8 @@ abstract contract ValidateUniswapMath is ConstantProductTestHarness {
         // 1:2.
 
         GPv2Order.Data memory order = getTradeableOrderWrapper(orderOwner, defaultData);
-        assertEq(address(order.sellToken), address(defaultData.token1));
-        assertEq(address(order.buyToken), address(defaultData.token0));
+        assertEq(address(order.sellToken), address(constantProduct.token1()));
+        assertEq(address(order.buyToken), address(constantProduct.token0()));
 
         // Assert explicit amounts to see that the trade is reasonable.
         assertEq(order.sellAmount, 10 ether);
@@ -51,7 +51,7 @@ abstract contract ValidateUniswapMath is ConstantProductTestHarness {
 
         GPv2Order.Data memory order = getTradeableOrderWrapper(orderOwner, defaultData);
         require(
-            address(order.sellToken) == address(defaultData.token0),
+            address(order.sellToken) == address(constantProduct.token0()),
             "this test was intended for the case sellToken == token0"
         );
         verifyWrapper(orderOwner, defaultData, order);
@@ -68,7 +68,7 @@ abstract contract ValidateUniswapMath is ConstantProductTestHarness {
 
         GPv2Order.Data memory order = getTradeableOrderWrapper(orderOwner, defaultData);
         require(
-            address(order.sellToken) == address(defaultData.token1),
+            address(order.sellToken) == address(constantProduct.token1()),
             "this test was intended for the case sellToken == token1"
         );
         verifyWrapper(orderOwner, defaultData, order);

--- a/test/CowAmmModule/CowAmmModuleTestHarness.sol
+++ b/test/CowAmmModule/CowAmmModuleTestHarness.sol
@@ -41,8 +41,8 @@ abstract contract CowAmmModuleTestHarness is BaseComposableCoWTest {
             )
         );
 
-        constantProduct = new ConstantProduct(address(settlement));
-        cowAmmModule = new CowAmmModule(settlement, eHandler, composableCow, constantProduct);
+        constantProduct = new ConstantProduct(address(settlement), token0, token1);
+        cowAmmModule = new CowAmmModule(settlement, eHandler, composableCow, constantProduct, token0, token1);
     }
 
     function setUpDefaultSafe() internal {
@@ -53,7 +53,7 @@ abstract contract CowAmmModuleTestHarness is BaseComposableCoWTest {
     }
 
     function getDefaultData() internal view returns (ConstantProduct.Data memory) {
-        return ConstantProduct.Data(token0, token1, 0, DEFAULT_PRICE_ORACLE, bytes("some oracle data"), DEFAULT_APPDATA);
+        return ConstantProduct.Data(0, DEFAULT_PRICE_ORACLE, bytes("some oracle data"), DEFAULT_APPDATA);
     }
 
     function setUpDefaultCowAmm() internal {
@@ -62,12 +62,7 @@ abstract contract CowAmmModuleTestHarness is BaseComposableCoWTest {
 
         vm.prank(address(safe));
         cowAmmModule.createAmm(
-            ammData.token0,
-            ammData.token1,
-            ammData.minTradedToken0,
-            address(ammData.priceOracle),
-            ammData.priceOracleData,
-            ammData.appData
+            ammData.minTradedToken0, address(ammData.priceOracle), ammData.priceOracleData, ammData.appData
         );
     }
 

--- a/test/CowAmmModule/CreateAmm.sol
+++ b/test/CowAmmModule/CreateAmm.sol
@@ -32,12 +32,7 @@ abstract contract CreateAmmTest is CowAmmModuleTestHarness {
         emit CowAmmModule.CowAmmCreated(safe, token0, token1, preCalculatedOrderHash);
 
         bytes32 orderHash = cowAmmModule.createAmm(
-            ammData.token0,
-            ammData.token1,
-            ammData.minTradedToken0,
-            address(ammData.priceOracle),
-            ammData.priceOracleData,
-            ammData.appData
+            ammData.minTradedToken0, address(ammData.priceOracle), ammData.priceOracleData, ammData.appData
         );
 
         assertEq(address(eHandler.domainVerifiers(safe, domainSeparator)), address(composableCow));
@@ -64,12 +59,7 @@ abstract contract CreateAmmTest is CowAmmModuleTestHarness {
         vm.prank(address(safe));
         vm.expectRevert(abi.encodeWithSelector(CowAmmModule.ActiveAMM.selector));
         cowAmmModule.createAmm(
-            ammData.token0,
-            ammData.token1,
-            ammData.minTradedToken0,
-            address(ammData.priceOracle),
-            ammData.priceOracleData,
-            ammData.appData
+            ammData.minTradedToken0, address(ammData.priceOracle), ammData.priceOracleData, ammData.appData
         );
     }
 
@@ -87,12 +77,7 @@ abstract contract CreateAmmTest is CowAmmModuleTestHarness {
         );
         vm.prank(address(safe));
         cowAmmModule.createAmm(
-            ammData.token0,
-            ammData.token1,
-            ammData.minTradedToken0,
-            address(ammData.priceOracle),
-            ammData.priceOracleData,
-            ammData.appData
+            ammData.minTradedToken0, address(ammData.priceOracle), ammData.priceOracleData, ammData.appData
         );
     }
 
@@ -110,48 +95,33 @@ abstract contract CreateAmmTest is CowAmmModuleTestHarness {
         );
         vm.prank(address(safe));
         cowAmmModule.createAmm(
-            ammData.token0,
-            ammData.token1,
-            ammData.minTradedToken0,
-            address(ammData.priceOracle),
-            ammData.priceOracleData,
-            ammData.appData
+            ammData.minTradedToken0, address(ammData.priceOracle), ammData.priceOracleData, ammData.appData
         );
     }
 
     function testRevertCalledFromSafeWithoutModuleEnabled() public {
         ConstantProduct.Data memory ammData = getDefaultData();
 
-        deal(address(ammData.token0), address(safe1), 100);
-        deal(address(ammData.token1), address(safe1), 100);
+        deal(address(cowAmmModule.token0()), address(safe1), 100);
+        deal(address(cowAmmModule.token1()), address(safe1), 100);
 
         vm.prank(address(safe1));
         vm.expectRevert("GS104");
         cowAmmModule.createAmm(
-            ammData.token0,
-            ammData.token1,
-            ammData.minTradedToken0,
-            address(ammData.priceOracle),
-            ammData.priceOracleData,
-            ammData.appData
+            ammData.minTradedToken0, address(ammData.priceOracle), ammData.priceOracleData, ammData.appData
         );
     }
 
     function testRevertCalledFromNonSafe() public {
         ConstantProduct.Data memory ammData = getDefaultData();
 
-        deal(address(ammData.token0), address(alice.addr), 100);
-        deal(address(ammData.token1), address(alice.addr), 100);
+        deal(address(cowAmmModule.token0()), address(alice.addr), 100);
+        deal(address(cowAmmModule.token1()), address(alice.addr), 100);
 
         vm.prank(address(alice.addr));
         vm.expectRevert();
         cowAmmModule.createAmm(
-            ammData.token0,
-            ammData.token1,
-            ammData.minTradedToken0,
-            address(ammData.priceOracle),
-            ammData.priceOracleData,
-            ammData.appData
+            ammData.minTradedToken0, address(ammData.priceOracle), ammData.priceOracleData, ammData.appData
         );
     }
 
@@ -164,12 +134,7 @@ abstract contract CreateAmmTest is CowAmmModuleTestHarness {
         vm.prank(address(safe));
         vm.expectRevert(abi.encodeWithSelector(CowAmmModule.TokenBalanceZero.selector));
         cowAmmModule.createAmm(
-            ammData.token0,
-            ammData.token1,
-            ammData.minTradedToken0,
-            address(ammData.priceOracle),
-            ammData.priceOracleData,
-            ammData.appData
+            ammData.minTradedToken0, address(ammData.priceOracle), ammData.priceOracleData, ammData.appData
         );
     }
 }

--- a/test/CowAmmModule/DeploymentParamsTest.sol
+++ b/test/CowAmmModule/DeploymentParamsTest.sol
@@ -9,8 +9,11 @@ abstract contract DeploymentParamsTest is CowAmmModuleTestHarness {
         require(address(eHandler) != address(0), "test should use a nonzero address");
         require(address(composableCow) != address(0), "test should use a nonzero address");
         require(address(constantProduct) != address(0), "test should use a nonzero address");
+        require(address(token0) != address(0), "test should use a nonzero address");
+        require(address(token1) != address(0), "test should use a nonzero address");
 
-        CowAmmModule cowAmmModule = new CowAmmModule(settlement, eHandler, composableCow, constantProduct);
+        CowAmmModule cowAmmModule =
+            new CowAmmModule(settlement, eHandler, composableCow, constantProduct, token0, token1);
 
         assertEq(address(cowAmmModule.SETTLER()), address(settlement));
         assertEq(address(cowAmmModule.EXTENSIBLE_FALLBACK_HANDLER()), address(eHandler));
@@ -18,5 +21,7 @@ abstract contract DeploymentParamsTest is CowAmmModuleTestHarness {
         assertEq(address(cowAmmModule.HANDLER()), address(constantProduct));
         assertEq(address(cowAmmModule.VAULT_RELAYER()), address(settlement.vaultRelayer()));
         assertEq(cowAmmModule.COW_DOMAIN_SEPARATOR(), settlement.domainSeparator());
+        assertEq(address(cowAmmModule.token0()), address(token0));
+        assertEq(address(cowAmmModule.token1()), address(token1));
     }
 }

--- a/test/CowAmmModule/ReplaceAmm.sol
+++ b/test/CowAmmModule/ReplaceAmm.sol
@@ -23,12 +23,7 @@ abstract contract ReplaceAmmTest is CowAmmModuleTestHarness {
         emit CowAmmModule.CowAmmCreated(safe, token0, token1, newPreCalculatedOrderHash);
 
         bytes32 orderHash = cowAmmModule.replaceAmm(
-            ammData.token0,
-            ammData.token1,
-            ammData.minTradedToken0,
-            address(ammData.priceOracle),
-            ammData.priceOracleData,
-            ammData.appData
+            ammData.minTradedToken0, address(ammData.priceOracle), ammData.priceOracleData, ammData.appData
         );
 
         assertTrue(orderHash != previousOrderHash);
@@ -48,12 +43,7 @@ abstract contract ReplaceAmmTest is CowAmmModuleTestHarness {
         vm.expectRevert(abi.encodeWithSelector(CowAmmModule.NoActiveOrderToReplace.selector));
 
         bytes32 orderHash = cowAmmModule.replaceAmm(
-            ammData.token0,
-            ammData.token1,
-            ammData.minTradedToken0,
-            address(ammData.priceOracle),
-            ammData.priceOracleData,
-            ammData.appData
+            ammData.minTradedToken0, address(ammData.priceOracle), ammData.priceOracleData, ammData.appData
         );
     }
 }

--- a/test/e2e/ConstantProduct.t.sol
+++ b/test/e2e/ConstantProduct.t.sol
@@ -26,11 +26,11 @@ contract E2EConditionalOrderTest is BaseComposableCoWTest {
 
     function setUp() public virtual override(BaseComposableCoWTest) {
         super.setUp();
-        constantProduct = new ConstantProduct(address(settlement));
-        uniswapV2PriceOracle = new UniswapV2PriceOracle();
-        domainSeparator = composableCow.domainSeparator();
         DAI = token0;
         WETH = token1;
+        constantProduct = new ConstantProduct(address(settlement), DAI, WETH);
+        uniswapV2PriceOracle = new UniswapV2PriceOracle();
+        domainSeparator = composableCow.domainSeparator();
         IUniswapV2Factory uniswapV2Factory = UniswapV2Helper.deployUniswapV2FactoryAt(
             vm, Utils.addressFromString("E2EConditionalOrderTest UniswapV2 factory")
         );
@@ -56,7 +56,7 @@ contract E2EConditionalOrderTest is BaseComposableCoWTest {
         (Safe amm, TestAccount[] memory owners) = deployAmmSafe();
 
         ConstantProduct.Data memory data = ConstantProduct.Data(
-            DAI, WETH, 0, uniswapV2PriceOracle, abi.encode(UniswapV2PriceOracle.Data(pair)), keccak256("order app data")
+            0, uniswapV2PriceOracle, abi.encode(UniswapV2PriceOracle.Data(pair)), keccak256("order app data")
         );
         IConditionalOrder.ConditionalOrderParams memory params =
             super.createOrder(constantProduct, keccak256("any salt"), abi.encode(data));

--- a/test/script/DeployAllContracts.t.sol
+++ b/test/script/DeployAllContracts.t.sol
@@ -17,6 +17,10 @@ contract DeployAllContractsTest is Test, BalancerSetUp, CowProtocolSetUp, SafeSe
         setUpComposableCowContract();
         setUpBalancerVault();
         setUpSafeExtensibleFallbackHandler();
+
+        vm.setEnv("TOKEN_0", "0x1111111111111111111111111111111111111111");
+        vm.setEnv("TOKEN_1", "0x2222222222222222222222222222222222222222");
+
         script = new DeployAllContracts();
     }
 

--- a/test/script/single-deployment/DeployConstantProduct.t.sol
+++ b/test/script/single-deployment/DeployConstantProduct.t.sol
@@ -12,6 +12,10 @@ contract DeployConstantProductTest is Test, CowProtocolSetUp {
 
     function setUp() public {
         setUpSettlementContract();
+
+        vm.setEnv("TOKEN_0", "0x1111111111111111111111111111111111111111");
+        vm.setEnv("TOKEN_1", "0x2222222222222222222222222222222222222222");
+
         script = new DeployConstantProduct();
     }
 

--- a/test/script/single-deployment/DeplyCowAmmModule.t.sol
+++ b/test/script/single-deployment/DeplyCowAmmModule.t.sol
@@ -22,6 +22,9 @@ contract DeployCowAmmModuleTest is Test, CowProtocolSetUp, SafeSetUp {
 
         vm.etch(ETCHED_HANDLER, hex"1337");
 
+        vm.setEnv("TOKEN_0", "0x1111111111111111111111111111111111111111");
+        vm.setEnv("TOKEN_1", "0x2222222222222222222222222222222222222222");
+
         script = new DeployCowAmmModule();
         goodScript = new DeployCowAmmModuleTestDeployer();
     }


### PR DESCRIPTION
First commit of a long series that reimplements CoW AMM as a standalone contract, rather than using `ConditionalCoW`.

These changes remove the AMM tokens from the parameters. They will be instead specified as an immutable deployment argument.

I didn't put much effort in revising the deployment script because eventually CoW AMM will be deployed by a dedicated factory contract, and those deployment scripts will be deleted. Also, the CoW AMM module will be repurposed and its logic revised.

Note that all commit related to making CoW AMM a standalone contract will be collected in a branch `standalone-contract`. I wanted to create a draft PR to have all changes visible from there, but it isn't possible to create a PR for a branch with no commits, so I'll do that once this is merged.

### How to test

CI.