### PR TITLE
Use transient storage for commitment

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -2,7 +2,8 @@
 src = "src"
 out = "out"
 libs = ["lib"]
-solc-version = "0.8.23"
+solc-version = "0.8.24"
+evm_version = "cancun"
 optimizer = true
 optimizer-runs = 100_000
 

--- a/foundry.toml
+++ b/foundry.toml
@@ -2,7 +2,7 @@
 src = "src"
 out = "out"
 libs = ["lib"]
-solc-version = "0.8.24"
+solc_version = "0.8.24"
 evm_version = "cancun"
 optimizer = true
 optimizer-runs = 100_000

--- a/script/DeployAllContracts.s.sol
+++ b/script/DeployAllContracts.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {DeployUniswapV2PriceOracle, UniswapV2PriceOracle} from "./single-deployment/UniswapV2PriceOracle.s.sol";
 import {DeployConstantProductFactory, ConstantProductFactory} from "./single-deployment/ConstantProductFactory.s.sol";

--- a/script/libraries/EnvReader.sol
+++ b/script/libraries/EnvReader.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {Script} from "forge-std/Script.sol";
 

--- a/script/libraries/Utils.sol
+++ b/script/libraries/Utils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {Script} from "forge-std/Script.sol";
 

--- a/script/single-deployment/BalancerWeightedPoolPriceOracle.s.sol
+++ b/script/single-deployment/BalancerWeightedPoolPriceOracle.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {console} from "forge-std/Script.sol";
 

--- a/script/single-deployment/ChainlinkPriceOracle.s.sol
+++ b/script/single-deployment/ChainlinkPriceOracle.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {Script} from "forge-std/Script.sol";
 

--- a/script/single-deployment/ConstantProductFactory.s.sol
+++ b/script/single-deployment/ConstantProductFactory.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {console} from "forge-std/Script.sol";
 

--- a/script/single-deployment/UniswapV2PriceOracle.s.sol
+++ b/script/single-deployment/UniswapV2PriceOracle.s.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {Script} from "forge-std/Script.sol";
 

--- a/src/ConstantProductFactory.sol
+++ b/src/ConstantProductFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {ComposableCoW, IConditionalOrder} from "lib/composable-cow/src/ComposableCoW.sol";
 import {SafeERC20} from "lib/composable-cow/lib/@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/src/interfaces/IBalancer.sol
+++ b/src/interfaces/IBalancer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {IERC20} from "lib/composable-cow/lib/@openzeppelin/contracts/interfaces/IERC20.sol";
 

--- a/src/interfaces/IPriceOracle.sol
+++ b/src/interfaces/IPriceOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 /**
  * @title CoW AMM Price Oracle Interface

--- a/src/interfaces/ISettlement.sol
+++ b/src/interfaces/ISettlement.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 /**
  * @title CoW Protocol Settlement Interface

--- a/src/interfaces/IWatchtowerCustomErrors.sol
+++ b/src/interfaces/IWatchtowerCustomErrors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 /**
  * @title Watchtower Custom Error Interface

--- a/src/oracles/BalancerWeightedPoolPriceOracle.sol
+++ b/src/oracles/BalancerWeightedPoolPriceOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {IConditionalOrder} from "lib/composable-cow/src/BaseConditionalOrder.sol";
 import {IERC20} from "lib/composable-cow/lib/@openzeppelin/contracts/interfaces/IERC20.sol";

--- a/src/oracles/ChainlinkPriceOracle.sol
+++ b/src/oracles/ChainlinkPriceOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {AggregatorV3Interface} from "../interfaces/AggregatorV3Interface.sol";
 import {IPriceOracle} from "../interfaces/IPriceOracle.sol";

--- a/src/oracles/UniswapV2PriceOracle.sol
+++ b/src/oracles/UniswapV2PriceOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {IUniswapV2Pair} from "lib/uniswap-v2-core/contracts/interfaces/IUniswapV2Pair.sol";
 

--- a/test/ConstantProduct.t.sol
+++ b/test/ConstantProduct.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {VerifyTest} from "./ConstantProduct/VerifyTest.sol";
 import {GetTradeableOrderTest} from "./ConstantProduct/GetTradeableOrderTest.sol";

--- a/test/ConstantProduct/CommitTest.sol
+++ b/test/ConstantProduct/CommitTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {Utils} from "test/libraries/Utils.sol";
 import {ConstantProductTestHarness, ConstantProduct} from "./ConstantProductTestHarness.sol";

--- a/test/ConstantProduct/ConstantProductTestHarness.sol
+++ b/test/ConstantProduct/ConstantProductTestHarness.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {BaseComposableCoWTest} from "lib/composable-cow/test/ComposableCoW.base.t.sol";
 

--- a/test/ConstantProduct/DeploymentParamsTest.sol
+++ b/test/ConstantProduct/DeploymentParamsTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {Utils} from "test/libraries/Utils.sol";
 

--- a/test/ConstantProduct/DisableTrading.sol
+++ b/test/ConstantProduct/DisableTrading.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {Utils} from "test/libraries/Utils.sol";
 

--- a/test/ConstantProduct/EnableTrading.sol
+++ b/test/ConstantProduct/EnableTrading.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {Utils} from "test/libraries/Utils.sol";
 

--- a/test/ConstantProduct/GetTradeableOrderTest.sol
+++ b/test/ConstantProduct/GetTradeableOrderTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {ValidateOrderParametersTest} from "./getTradeableOrder/ValidateOrderParametersTest.sol";
 import {ValidateUniswapMath} from "./getTradeableOrder/ValidateUniswapMath.sol";

--- a/test/ConstantProduct/IsValidSignature.sol
+++ b/test/ConstantProduct/IsValidSignature.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {ValidateOrderHash} from "./isValidSignature/ValidateOrderHash.sol";
 import {EnforceCommitmentTest} from "./isValidSignature/EnforceCommitmentTest.sol";

--- a/test/ConstantProduct/VerifyTest.sol
+++ b/test/ConstantProduct/VerifyTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {ValidateOrderParametersTest} from "./verify/ValidateOrderParametersTest.sol";
 import {ValidateAmmMath} from "./verify/ValidateAmmMath.sol";

--- a/test/ConstantProduct/getTradeableOrder/ValidateOrderParametersTest.sol
+++ b/test/ConstantProduct/getTradeableOrder/ValidateOrderParametersTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {ConstantProduct, GPv2Order} from "src/ConstantProduct.sol";
 import {IWatchtowerCustomErrors} from "src/interfaces/IWatchtowerCustomErrors.sol";

--- a/test/ConstantProduct/getTradeableOrder/ValidateUniswapMath.sol
+++ b/test/ConstantProduct/getTradeableOrder/ValidateUniswapMath.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {ConstantProduct, GPv2Order} from "src/ConstantProduct.sol";
 

--- a/test/ConstantProduct/isValidSignature/EnforceCommitmentTest.sol
+++ b/test/ConstantProduct/isValidSignature/EnforceCommitmentTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {ConstantProduct, GPv2Order, IERC20, IConditionalOrder} from "src/ConstantProduct.sol";
 

--- a/test/ConstantProduct/isValidSignature/ValidateOrderHash.sol
+++ b/test/ConstantProduct/isValidSignature/ValidateOrderHash.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {IERC1271} from "lib/openzeppelin/contracts/interfaces/IERC1271.sol";
 

--- a/test/ConstantProduct/verify/ValidateAmmMath.sol
+++ b/test/ConstantProduct/verify/ValidateAmmMath.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {ConstantProduct, GPv2Order, IERC20, IConditionalOrder} from "src/ConstantProduct.sol";
 import {UniswapV2PriceOracle, IUniswapV2Pair} from "src/oracles/UniswapV2PriceOracle.sol";

--- a/test/ConstantProduct/verify/ValidateOrderParametersTest.sol
+++ b/test/ConstantProduct/verify/ValidateOrderParametersTest.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {ConstantProduct, GPv2Order, IERC20, IConditionalOrder} from "src/ConstantProduct.sol";
 

--- a/test/ConstantProductFactory.t.sol
+++ b/test/ConstantProductFactory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {GetTradeableOrderWithSignature} from "./ConstantProductFactory/GetTradeableOrderWithSignature.sol";
 import {Deposit} from "./ConstantProductFactory/Deposit.sol";

--- a/test/ConstantProductFactory/ConstantProductFactoryTestHarness.sol
+++ b/test/ConstantProductFactory/ConstantProductFactoryTestHarness.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {
     ConstantProductFactory,

--- a/test/ConstantProductFactory/Create.sol
+++ b/test/ConstantProductFactory/Create.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {CreateAMM} from "./Create/CreateAMM.sol";
 import {DeterministicDeployment} from "./Create/DeterministicDeployment.sol";

--- a/test/ConstantProductFactory/Create/CreateAMM.sol
+++ b/test/ConstantProductFactory/Create/CreateAMM.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {
     IERC20,

--- a/test/ConstantProductFactory/Create/DeterministicDeployment.sol
+++ b/test/ConstantProductFactory/Create/DeterministicDeployment.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {IPriceOracle, ConstantProduct, IERC20} from "src/ConstantProductFactory.sol";
 

--- a/test/ConstantProductFactory/Deposit.sol
+++ b/test/ConstantProductFactory/Deposit.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {IERC20} from "src/ConstantProductFactory.sol";
 

--- a/test/ConstantProductFactory/DisableTrading.sol
+++ b/test/ConstantProductFactory/DisableTrading.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {ConstantProduct, ConstantProductFactory, IPriceOracle} from "src/ConstantProductFactory.sol";
 

--- a/test/ConstantProductFactory/GetTradeableOrderWithSignature.sol
+++ b/test/ConstantProductFactory/GetTradeableOrderWithSignature.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {IERC1271} from "lib/openzeppelin/contracts/interfaces/IERC1271.sol";
 import {IConditionalOrder} from "lib/composable-cow/src/BaseConditionalOrder.sol";

--- a/test/ConstantProductFactory/UpdateParameters.sol
+++ b/test/ConstantProductFactory/UpdateParameters.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {
     IPriceOracle,

--- a/test/ConstantProductFactory/Withdraw.sol
+++ b/test/ConstantProductFactory/Withdraw.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {ConstantProductFactory, IERC20} from "src/ConstantProductFactory.sol";
 

--- a/test/e2e/ConstantProduct.t.sol
+++ b/test/e2e/ConstantProduct.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {BaseComposableCoWTest} from "lib/composable-cow/test/ComposableCoW.base.t.sol";
 

--- a/test/libraries/UniswapV2Helper.sol
+++ b/test/libraries/UniswapV2Helper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {Vm} from "forge-std/Vm.sol";
 import {IUniswapV2Factory} from "lib/uniswap-v2-core/contracts/interfaces/IUniswapV2Factory.sol";

--- a/test/libraries/Utils.sol
+++ b/test/libraries/Utils.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 library Utils {
     function addressFromString(string memory s) internal pure returns (address) {

--- a/test/oracles/BalancerWeightedPoolPriceOracle.sol
+++ b/test/oracles/BalancerWeightedPoolPriceOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {Test} from "forge-std/Test.sol";
 import {IERC20} from "lib/composable-cow/lib/@openzeppelin/contracts/interfaces/IERC20.sol";

--- a/test/oracles/BalancerWeightedPoolPriceOracle/OutputByteReduction.sol
+++ b/test/oracles/BalancerWeightedPoolPriceOracle/OutputByteReduction.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {Test} from "forge-std/Test.sol";
 

--- a/test/oracles/BalancerWeightedPoolPriceOracle/Parameters.sol
+++ b/test/oracles/BalancerWeightedPoolPriceOracle/Parameters.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {Test} from "forge-std/Test.sol";
 

--- a/test/oracles/ChainlinkPriceOracle.sol
+++ b/test/oracles/ChainlinkPriceOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {Test, console2} from "forge-std/Test.sol";
 

--- a/test/oracles/UniswapV2PriceOracle.sol
+++ b/test/oracles/UniswapV2PriceOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {Test} from "forge-std/Test.sol";
 

--- a/test/script/DeployAllContracts.t.sol
+++ b/test/script/DeployAllContracts.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {Test} from "forge-std/Test.sol";
 

--- a/test/script/single-deployment/DeployBalancerWeightedPoolPriceOracle.t.sol
+++ b/test/script/single-deployment/DeployBalancerWeightedPoolPriceOracle.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {Test} from "forge-std/Test.sol";
 

--- a/test/script/single-deployment/DeployChainlinkPriceOracle.sol
+++ b/test/script/single-deployment/DeployChainlinkPriceOracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {Test} from "forge-std/Test.sol";
 

--- a/test/script/single-deployment/DeployConstantProductFactory.t.sol
+++ b/test/script/single-deployment/DeployConstantProductFactory.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {Test} from "forge-std/Test.sol";
 

--- a/test/script/single-deployment/DeployUniswapV2PriceOracle.t.sol
+++ b/test/script/single-deployment/DeployUniswapV2PriceOracle.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {Test} from "forge-std/Test.sol";
 

--- a/test/script/single-deployment/balancer/BalancerSetUp.sol
+++ b/test/script/single-deployment/balancer/BalancerSetUp.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {Test} from "forge-std/Test.sol";
 

--- a/test/script/single-deployment/cow-protocol/CowProtocolSetUp.sol
+++ b/test/script/single-deployment/cow-protocol/CowProtocolSetUp.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: GPL-3.0
-pragma solidity >=0.8.0 <0.9.0;
+pragma solidity ^0.8.24;
 
 import {Test} from "forge-std/Test.sol";
 


### PR DESCRIPTION
Transient storage is a simple gas optimization that makes custom orders cheaper to execute with very limited drawbacks.
It has been discussed previously when introducing the commit functionality (85f68f62147689b1df4b21748b11758a2b7ee70d) and has been mentioned in the audit as a form of mitigation for a minor DoS vector by solvers.

Gas analysis (below) show that this leads to savings of ~22k gas when settling a custom order and ~2k gas when settling the default order. This comes to a surprising deployment price increase of ~31k, which is on the other hand rather inconsequential.

This change means that we now require a minimum Solidity compiler version of 0.8.24, where transient storage was introduced. Interestingly, this compiler version bump by itself gives additional minor gas improvements.

<details><summary>Snapshot difference with previous commit</summary>

```
testSameOwnerCannotDeployAMMWithSameParametersTwice() (gas: 242 (0.000%)) 
testDisableTradingUnsetsState() (gas: -1 (-0.003%)) 
test_SetUpState_ComposableCoWDomainVerifier_is_set() (gas: -7 (-0.040%)) 
test_SetUpState_ComposableCoWDomainVerifier_is_set() (gas: -7 (-0.040%)) 
test_SetUpState_ComposableCoWDomainVerifier_is_set() (gas: -7 (-0.040%)) 
testVaultAddress() (gas: -4 (-0.041%)) 
testToleranceIsLessThanOneBasePoint() (gas: -1 (-0.042%)) 
test_SetUpState_ComposableCoWDomainSeparator_is_set() (gas: -6 (-0.056%)) 
test_SetUpState_ComposableCoWDomainSeparator_is_set() (gas: -6 (-0.056%)) 
test_SetUpState_ComposableCoWDomainSeparator_is_set() (gas: -6 (-0.056%)) 
testEnableTradingDoesNotRevert() (gas: -25 (-0.063%)) 
testDisableTradingRevertsIfCalledByNonManager() (gas: -36 (-0.082%)) 
testDisableTradingDoesNotRevert() (gas: -26 (-0.090%)) 
testDisableTradingEmitsEvent() (gas: -30 (-0.095%)) 
testEnableTradingEmitsEvent() (gas: -48 (-0.099%)) 
testEnableTradingSetsState() (gas: -44 (-0.102%)) 
testRevertsIfOrderInSignatureDoesNotMatchOrderHash() (gas: -65 (-0.106%)) 
testRevertsIfPoolNotRegistered() (gas: -28 (-0.112%)) 
testReturnsInvertedPrice() (gas: -27 (-0.117%)) 
testReturnsExpectedPrice() (gas: -28 (-0.121%)) 
testEnableTradingRevertsIfCalledByNonManager() (gas: -20 (-0.122%)) 
testRevertsIfOracleIsStale() (gas: -32 (-0.122%)) 
testRevertsIfStaticInputHashDoesNotMatchTradingParamsHash() (gas: -43 (-0.123%)) 
testReturnsExpectedPrice() (gas: -22 (-0.128%)) 
testInvertsPriceIfTokensAreInverted() (gas: -22 (-0.129%)) 
testRevertsIfPairUsesIncorrectToken1() (gas: -23 (-0.129%)) 
testRevertsIfPairUsesIncorrectToken0() (gas: -23 (-0.130%)) 
testRevertsIfPairUsesIncorrectTokenWhenInverted() (gas: -23 (-0.130%)) 
testCommitIsPermissioned() (gas: -12 (-0.130%)) 
testNormalizedDecimals() (gas: -31 (-0.131%)) 
testRevertsIfNoTokensAvailable() (gas: -39 (-0.151%)) 
testRevertsIfHandlerIsNotFactory() (gas: -37 (-0.155%)) 
testRevertsUnsupportedDecimals() (gas: -50 (-0.174%)) 
testAmmIsNotTradingAfterDeployment() (gas: 15 (0.181%)) 
testCapsReductionIfMinAmountWouldGoBelowTolerance() (gas: -17 (-0.182%)) 
testE2ESettle() (gas: 4614 (0.189%)) 
testAnyoneCanDeposit() (gas: -51 (-0.195%)) 
testRevertsIfOneOracleIsStale() (gas: -86 (-0.215%)) 
testRevertsIfAnyDepositReverts() (gas: -52 (-0.222%)) 
testRevertsIfTradingWithDifferentParameters() (gas: -181 (-0.227%)) 
testReducesAmountExplicitBytes() (gas: -16 (-0.228%)) 
testReducesAmountRoundingMaxUp() (gas: -16 (-0.230%)) 
testReducesAmount() (gas: -17 (-0.244%)) 
testReducesAmountWhenSecondLarger() (gas: -17 (-0.245%)) 
testOrderMatchesTradeableOrder() (gas: -270 (-0.262%)) 
testRevertsIfToken0IsNotPartOfThePool() (gas: -91 (-0.265%)) 
testOnlyCallsTransferFromOnDeposit() (gas: -57 (-0.265%)) 
testRobustForMultipleTokens() (gas: -103 (-0.265%)) 
testReturnsInputIfMinBelowTolerance() (gas: -31 (-0.265%)) 
testRevertsIfToken1IsNotPartOfThePool() (gas: -92 (-0.267%)) 
testRevertsIfTokenReturnsFalseOnDeposit() (gas: -58 (-0.269%)) 
testRevertsIfNoWeightsAvailable() (gas: -97 (-0.273%)) 
testPriceWithNonUniformWeights() (gas: -101 (-0.277%)) 
testComputesExpectedPriceWithUniformWeightsInvertedOrder() (gas: -101 (-0.277%)) 
testComputesExpectedPriceWithUniformWeights() (gas: -101 (-0.278%)) 
testSellAmountSubtractionUnderflow() (gas: -121 (-0.291%)) 
testPriceFromActualCowWethPoolValues() (gas: -101 (-0.295%)) 
testValidOrderParameters() (gas: -139 (-0.296%)) 
testReturnedTradeValues() (gas: -169 (-0.324%)) 
testPriceFromActualComplexPoolValues() (gas: -149 (-0.324%)) 
testReturnedTradeValuesOtherSide() (gas: -170 (-0.326%)) 
testGeneratedTradeWithRoundingErrors() (gas: -183 (-0.326%)) 
testGeneratedInvertedTradeWithRoundingErrors() (gas: -185 (-0.329%)) 
testOrderValidityMovesToNextBucket() (gas: -215 (-0.333%)) 
testReturnsInputIfAmountsAreSmall() (gas: -32 (-0.342%)) 
testRevertsIfAmountTooLowOnSellToken() (gas: -262 (-0.362%)) 
testRevertsIfAmountTooLowOnBuyToken() (gas: -263 (-0.363%)) 
testUpdatingEmitsExpectedEvents() (gas: 7523 (0.409%)) 
testUpdatesTradingParamsHash() (gas: 7523 (0.410%)) 
testOnlyOwnerCanUpdateParams() (gas: 7576 (0.417%)) 
testCreationEmitsEvents() (gas: 7582 (0.417%)) 
testNewAMMHasExpectedTokens() (gas: 7578 (0.418%)) 
testNewAMMEnablesTrading() (gas: 7582 (0.418%)) 
testCreationSetsOwner() (gas: 7587 (0.419%)) 
testCreationTransfersInExpectedAmounts() (gas: 7589 (0.419%)) 
testDeploysAtExpectedAddress() (gas: 7599 (0.420%)) 
testOnlyOwnerCanDisableTrading() (gas: 7579 (0.421%)) 
testDifferentOwnersCanDeployAMMWithSameParameters() (gas: 15199 (0.424%)) 
testSameOwnerCanDeployAMMWithDifferentTokens() (gas: 15201 (0.424%)) 
testDisableTradingEmitsExpectedEvents() (gas: 7581 (0.426%)) 
testResetsTradingParamsHash() (gas: 7602 (0.427%)) 
testDeploymentAllowsVaultRelayer() (gas: 7639 (0.450%)) 
testDeploymentAllowsDeployer() (gas: 7644 (0.450%)) 
testSetsDeploymentParameters() (gas: 7664 (0.451%)) 
testDeploymentSucceedsIfApproveReturnsNoData() (gas: 7667 (0.452%)) 
testDoesNotRevert() (gas: -26202 (-0.747%)) 
testCallsTransferFromOnWithdraw() (gas: -27049 (-0.753%)) 
testRevertsIfAnyDepositRevertsOnWithdraw() (gas: -27052 (-0.754%)) 
testOnlyCallsTransferFromOnWithdraw() (gas: -27057 (-0.754%)) 
testRevertsIfTokenReturnsFalseOnWithdraw() (gas: -27058 (-0.755%)) 
testWithdrawingIsPermissioned() (gas: -27013 (-0.756%)) 
testDeploymentRevertsIfApprovalReverts() (gas: 492 (0.779%)) 
testDeploymentRevertsIfApprovalReturnsFalse() (gas: 509 (0.837%)) 
testZeroCommitRevertsForOrdersOtherThanTradeableOrder() (gas: -3246 (-1.003%)) 
testDoesNotRevert() (gas: -54667 (-1.111%)) 
testDoesNotRevert() (gas: -13044 (-1.898%)) 
testDoesNotRevert() (gas: -8714 (-2.015%)) 
testSignatureIsValid() (gas: -2278 (-2.091%)) 
testDoesNotRevert() (gas: -6736 (-2.120%)) 
testTradeableOrderPassesValidationWithZeroCommit() (gas: -2271 (-2.338%)) 
testRevertsIfInvalidTokenCombination() (gas: -22296 (-20.353%)) 
testReturnsMagicValueIfTradeable() (gas: -22165 (-21.237%)) 
testRevertsIfCommitDoesNotMatch() (gas: -22149 (-22.428%)) 
testRevertsIfVerificationFails() (gas: -22066 (-26.004%)) 
testRevertsIfExpiresFarInTheFuture() (gas: -22119 (-32.219%)) 
testInvertedTokensOneTooLittleIn() (gas: -22097 (-32.466%)) 
testInvertedTokenOneTooMuchOut() (gas: -22097 (-32.472%)) 
testOneTooLittleIn() (gas: -22096 (-32.516%)) 
testOneTooMuchOut() (gas: -22096 (-32.520%)) 
testRevertsIfSellTokenBalanceIsNotErc20() (gas: -22116 (-32.626%)) 
testRevertsIfDifferentAppData() (gas: -22116 (-32.630%)) 
testRevertsIfNonzeroFee() (gas: -22116 (-32.647%)) 
testRevertsIfBuyTokenBalanceIsNotErc20() (gas: -22116 (-32.654%)) 
testRevertsIfDifferentReceiver() (gas: -22116 (-32.719%)) 
testCanInvertTokens() (gas: -22111 (-32.944%)) 
testDefaultDoesNotRevert() (gas: -22110 (-33.017%)) 
testInvertInOutToken() (gas: -22091 (-33.023%)) 
testExactAmountsInOut() (gas: -22090 (-33.052%)) 
testInvertedTokenVeryLargeBuyAmountDoesNotRevert() (gas: -22086 (-33.246%)) 
testVeryLargeBuyAmountDoesNotRevert() (gas: -22086 (-33.258%)) 
testInvertedTokenVeryLowSellAmountDoesNotRevert() (gas: -22086 (-33.258%)) 
testVeryLowSellAmountDoesNotRevert() (gas: -22086 (-33.268%)) 
testCommittingSetsCommitment() (gas: -21936 (-64.116%)) 
testSolutionSettlerCanSetAnyCommit() (gas: -22002 (-67.507%)) 
Overall gas change: -629368 (-0.000%)
```
</details>

<details><summary>Snapshot difference with previous commit using Solidity 0.8.24</summary>

```
testCommitIsPermissioned() (gas: 0 (0.000%)) 
testEnableTradingRevertsIfCalledByNonManager() (gas: 0 (0.000%)) 
testGeneratedInvertedTradeWithRoundingErrors() (gas: 0 (0.000%)) 
testGeneratedTradeWithRoundingErrors() (gas: 0 (0.000%)) 
testOrderValidityMovesToNextBucket() (gas: 0 (0.000%)) 
testReturnedTradeValues() (gas: 0 (0.000%)) 
testReturnedTradeValuesOtherSide() (gas: 0 (0.000%)) 
testRevertsIfAmountTooLowOnBuyToken() (gas: 0 (0.000%)) 
testRevertsIfAmountTooLowOnSellToken() (gas: 0 (0.000%)) 
testSellAmountSubtractionUnderflow() (gas: 0 (0.000%)) 
testValidOrderParameters() (gas: 0 (0.000%)) 
test_SetUpState_ComposableCoWDomainSeparator_is_set() (gas: 0 (0.000%)) 
test_SetUpState_ComposableCoWDomainVerifier_is_set() (gas: 0 (0.000%)) 
testAnyoneCanDeposit() (gas: 0 (0.000%)) 
testOnlyCallsTransferFromOnDeposit() (gas: 0 (0.000%)) 
testRevertsIfAnyDepositReverts() (gas: 0 (0.000%)) 
testRevertsIfHandlerIsNotFactory() (gas: 0 (0.000%)) 
testRevertsIfTokenReturnsFalseOnDeposit() (gas: 0 (0.000%)) 
test_SetUpState_ComposableCoWDomainSeparator_is_set() (gas: 0 (0.000%)) 
test_SetUpState_ComposableCoWDomainVerifier_is_set() (gas: 0 (0.000%)) 
test_SetUpState_ComposableCoWDomainSeparator_is_set() (gas: 0 (0.000%)) 
test_SetUpState_ComposableCoWDomainVerifier_is_set() (gas: 0 (0.000%)) 
testComputesExpectedPriceWithUniformWeights() (gas: 0 (0.000%)) 
testComputesExpectedPriceWithUniformWeightsInvertedOrder() (gas: 0 (0.000%)) 
testPriceFromActualComplexPoolValues() (gas: 0 (0.000%)) 
testPriceFromActualCowWethPoolValues() (gas: 0 (0.000%)) 
testPriceWithNonUniformWeights() (gas: 0 (0.000%)) 
testRevertsIfNoTokensAvailable() (gas: 0 (0.000%)) 
testRevertsIfNoWeightsAvailable() (gas: 0 (0.000%)) 
testRevertsIfPoolNotRegistered() (gas: 0 (0.000%)) 
testRevertsIfToken0IsNotPartOfThePool() (gas: 0 (0.000%)) 
testRevertsIfToken1IsNotPartOfThePool() (gas: 0 (0.000%)) 
testRobustForMultipleTokens() (gas: 0 (0.000%)) 
testCapsReductionIfMinAmountWouldGoBelowTolerance() (gas: 0 (0.000%)) 
testReducesAmount() (gas: 0 (0.000%)) 
testReducesAmountExplicitBytes() (gas: 0 (0.000%)) 
testReducesAmountRoundingMaxUp() (gas: 0 (0.000%)) 
testReducesAmountWhenSecondLarger() (gas: 0 (0.000%)) 
testReturnsInputIfAmountsAreSmall() (gas: 0 (0.000%)) 
testReturnsInputIfMinBelowTolerance() (gas: 0 (0.000%)) 
testToleranceIsLessThanOneBasePoint() (gas: 0 (0.000%)) 
testVaultAddress() (gas: 0 (0.000%)) 
testNormalizedDecimals() (gas: 0 (0.000%)) 
testReturnsExpectedPrice() (gas: 0 (0.000%)) 
testReturnsInvertedPrice() (gas: 0 (0.000%)) 
testRevertsIfOneOracleIsStale() (gas: 0 (0.000%)) 
testRevertsIfOracleIsStale() (gas: 0 (0.000%)) 
testRevertsUnsupportedDecimals() (gas: 0 (0.000%)) 
testInvertsPriceIfTokensAreInverted() (gas: 0 (0.000%)) 
testReturnsExpectedPrice() (gas: 0 (0.000%)) 
testRevertsIfPairUsesIncorrectToken0() (gas: 0 (0.000%)) 
testRevertsIfPairUsesIncorrectToken1() (gas: 0 (0.000%)) 
testRevertsIfPairUsesIncorrectTokenWhenInverted() (gas: 0 (0.000%)) 
testDoesNotRevert() (gas: 0 (0.000%)) 
testDoesNotRevert() (gas: 0 (0.000%)) 
testDoesNotRevert() (gas: 0 (0.000%)) 
testSameOwnerCannotDeployAMMWithSameParametersTwice() (gas: 967 (0.000%)) 
testOrderMatchesTradeableOrder() (gas: -2 (-0.002%)) 
testEnableTradingEmitsEvent() (gas: -1 (-0.002%)) 
testDisableTradingRevertsIfCalledByNonManager() (gas: -1 (-0.002%)) 
testRevertsIfTradingWithDifferentParameters() (gas: -2 (-0.003%)) 
testEnableTradingDoesNotRevert() (gas: -1 (-0.003%)) 
testRevertsIfStaticInputHashDoesNotMatchTradingParamsHash() (gas: -1 (-0.003%)) 
testRevertsIfOrderInSignatureDoesNotMatchOrderHash() (gas: -2 (-0.003%)) 
testEnableTradingSetsState() (gas: -2 (-0.005%)) 
testDisableTradingDoesNotRevert() (gas: -3 (-0.010%)) 
testDisableTradingEmitsEvent() (gas: -4 (-0.013%)) 
testDeploymentRevertsIfApprovalReverts() (gas: 47 (0.074%)) 
testDeploymentRevertsIfApprovalReturnsFalse() (gas: 47 (0.077%)) 
testDisableTradingUnsetsState() (gas: 32 (0.103%)) 
testAmmIsNotTradingAfterDeployment() (gas: 22 (0.266%)) 
testZeroCommitRevertsForOrdersOtherThanTradeableOrder() (gas: -2014 (-0.624%)) 
testDoesNotRevert() (gas: 30692 (0.635%)) 
testCallsTransferFromOnWithdraw() (gas: 30683 (0.869%)) 
testRevertsIfAnyDepositRevertsOnWithdraw() (gas: 30683 (0.869%)) 
testRevertsIfTokenReturnsFalseOnWithdraw() (gas: 30683 (0.870%)) 
testOnlyCallsTransferFromOnWithdraw() (gas: 30683 (0.870%)) 
testWithdrawingIsPermissioned() (gas: 30683 (0.873%)) 
testDoesNotRevert() (gas: 30692 (0.889%)) 
testE2ESettle() (gas: 28707 (1.188%)) 
testUpdatingEmitsExpectedEvents() (gas: 31142 (1.713%)) 
testUpdatesTradingParamsHash() (gas: 31140 (1.719%)) 
testCreationEmitsEvents() (gas: 31146 (1.737%)) 
testOnlyOwnerCanUpdateParams() (gas: 31146 (1.738%)) 
testNewAMMHasExpectedTokens() (gas: 31145 (1.740%)) 
testNewAMMEnablesTrading() (gas: 31145 (1.742%)) 
testCreationSetsOwner() (gas: 31146 (1.743%)) 
testDeploysAtExpectedAddress() (gas: 31146 (1.743%)) 
testCreationTransfersInExpectedAmounts() (gas: 31146 (1.743%)) 
testOnlyOwnerCanDisableTrading() (gas: 31146 (1.755%)) 
testDifferentOwnersCanDeployAMMWithSameParameters() (gas: 62292 (1.759%)) 
testSameOwnerCanDeployAMMWithDifferentTokens() (gas: 62292 (1.760%)) 
testDisableTradingEmitsExpectedEvents() (gas: 31143 (1.772%)) 
testResetsTradingParamsHash() (gas: 31165 (1.774%)) 
testDeploymentAllowsVaultRelayer() (gas: 30678 (1.831%)) 
testDeploymentAllowsDeployer() (gas: 30678 (1.831%)) 
testSetsDeploymentParameters() (gas: 30682 (1.832%)) 
testDeploymentSucceedsIfApproveReturnsNoData() (gas: 30683 (1.835%)) 
testSignatureIsValid() (gas: -2002 (-1.842%)) 
testTradeableOrderPassesValidationWithZeroCommit() (gas: -2014 (-2.079%)) 
testRevertsIfInvalidTokenCombination() (gas: -21994 (-20.132%)) 
testReturnsMagicValueIfTradeable() (gas: -21995 (-21.109%)) 
testRevertsIfCommitDoesNotMatch() (gas: -21995 (-22.307%)) 
testRevertsIfVerificationFails() (gas: -21995 (-25.942%)) 
testRevertsIfExpiresFarInTheFuture() (gas: -21994 (-32.095%)) 
testInvertedTokensOneTooLittleIn() (gas: -21994 (-32.364%)) 
testInvertedTokenOneTooMuchOut() (gas: -21994 (-32.369%)) 
testOneTooLittleIn() (gas: -21994 (-32.415%)) 
testOneTooMuchOut() (gas: -21994 (-32.419%)) 
testRevertsIfSellTokenBalanceIsNotErc20() (gas: -21994 (-32.504%)) 
testRevertsIfDifferentAppData() (gas: -21994 (-32.508%)) 
testRevertsIfNonzeroFee() (gas: -21994 (-32.525%)) 
testRevertsIfBuyTokenBalanceIsNotErc20() (gas: -21994 (-32.532%)) 
testRevertsIfDifferentReceiver() (gas: -21994 (-32.598%)) 
testCanInvertTokens() (gas: -21994 (-32.827%)) 
testDefaultDoesNotRevert() (gas: -21994 (-32.901%)) 
testInvertInOutToken() (gas: -21994 (-32.926%)) 
testExactAmountsInOut() (gas: -21994 (-32.956%)) 
testInvertedTokenVeryLargeBuyAmountDoesNotRevert() (gas: -21994 (-33.153%)) 
testVeryLargeBuyAmountDoesNotRevert() (gas: -21994 (-33.165%)) 
testInvertedTokenVeryLowSellAmountDoesNotRevert() (gas: -21994 (-33.165%)) 
testVeryLowSellAmountDoesNotRevert() (gas: -21994 (-33.175%)) 
testCommittingSetsCommitment() (gas: -21920 (-64.099%)) 
testSolutionSettlerCanSetAnyCommit() (gas: -21994 (-67.499%)) 
Overall gas change: 331848 (0.000%)
```
</details>

### How to test

Existing unit tests. Unfortunately, we can't do more sophisticated tests (for example making sure that the commitment is indeed cleared after the transaction) because to my understanding Foundry doesn't implement dedicated tooling to switch to different execution contexts (to simulate a new transaction and thus clear transient storage).