### PR TITLE
Improve solver documentation and events

### DIFF
--- a/docs/amm.md
+++ b/docs/amm.md
@@ -108,10 +108,10 @@ Every supported chain has an official factory contract, specified in the file `n
 
 The creation of new AMMs emits a `Deployed` event from the factory, which lists the AMM address, its owner, and the traded tokens.
 Owner and traded tokens will never change for the AMM identified by that address.
-No AMM can trade more than a single pair of tokens.
+No AMM created by the factory can trade more than a single pair of tokens.
 
-Every time a CoW AMM becomes available for trading on CoW Swap, the factory emits an event `ComposableCoW.ConditionalOrderCreated` with the AMM address and the abi-encoded trading parameters.
-This event is fired both for newly deployed AMM and for CoW AMM whose trading has been reenabled after having had been disabled.
+Every time a CoW AMM becomes available for trading on CoW Swap, the factory emits an event `ComposableCoW.ConditionalOrderCreated` with the AMM address and the ABI-encoded trading parameters.
+This event is fired both for newly deployed AMMs and for CoW AMMs whose trading has been re-enabled after having had been disabled.
 Unlike the AMM deployment parameters, trading parameters _can_ change during the lifetime of the AMM.
 However, at any point in time there can be at most one set of valid trading parameters.
 
@@ -140,7 +140,7 @@ You also need to compute:
 - the order signature (`abi.encode(order, tradingParams)`, where `order` is the order parameters in the `GPv2Order.Data` format and `tradingParams` are the currently enabled trading parameters as indicated by the latest fired event `ComposableCoW.ConditionalOrderCreated`).
 
 This order can be included in a batch as any other CoW Protocol orders with two extra conditions:
-- One of the pre-interaction must set the commitment by calling `ConstantProduct.commit(hash)`.
+- A pre-interaction must set the commitment by calling `ConstantProduct.commit(hash)`.
 - The batch must contain at most one order from the same AMM.
 
 ## Risk profile

--- a/docs/amm.md
+++ b/docs/amm.md
@@ -83,7 +83,7 @@ While this oracle is intended to support Chainlink Data Feed, it can also read f
 
 Some feed like Forex and commodity pair will not avaliable outside their market hours. Consider setting `2 days` as backoff duration for those address.
 
-If foundry is available in your system, you can generate the bytes calldata with the following command:
+If Foundry is available in your system, you can generate the bytes calldata with the following command:
 ```sh
 token0Feed=0x1111111111111111111111111111111111111111
 token1Feed=0x2222222222222222222222222222222222222222
@@ -142,6 +142,28 @@ You also need to compute:
 This order can be included in a batch as any other CoW Protocol orders with two extra conditions:
 - A pre-interaction must set the commitment by calling `ConstantProduct.commit(hash)`.
 - The batch must contain at most one order from the same AMM.
+
+#### Signature encoding example
+
+If Foundry is available in your system, you can generate the signature bytes with the following command:
+```sh
+sellToken='0xaa111111111111111111111111111111111111aa'
+buyToken='0xaa222222222222222222222222222222222222aa'
+receiver='0x0000000000000000000000000000000000000000'
+sellAmount='333'
+buyAmount='444'
+validTo='555'
+appData='0x6666666666666666666666666666666666666666666666666666666666666666'
+feeAmount='0'
+kind='f3b277728b3fee749481eb3e0b3b48980dbbab78658fc419025cb16eee346775' # sell
+partiallyFillable='true'
+sellTokenBalance='5a28e9363bb942b639270062aa6bb295f434bcdfc42c97267bf003f272060dc9' # erc20
+buyTokenBalance='5a28e9363bb942b639270062aa6bb295f434bcdfc42c97267bf003f272060dc9' # erc20
+minTradedToken0='777'
+priceOracle='0xaa888888888888888888888888888888888888aa'
+priceOracleData='0x9999'
+cast abi-encode 'f((address,address,address,uint256,uint256,uint32,bytes32,uint256,bytes32,bool,bytes32,bytes32),(uint256,address,bytes,bytes32))' "($sellToken,$buyToken,$receiver,$sellAmount,$buyAmount,$validTo,$appData,$feeAmount,$kind,$partiallyFillable,$sellTokenBalance,$buyTokenBalance)" "($minTradedToken0,$priceOracle,$priceOracleData,$appData)"
+```
 
 ## Risk profile
 

--- a/test/ConstantProductFactory/Create/CreateAMM.sol
+++ b/test/ConstantProductFactory/Create/CreateAMM.sol
@@ -99,7 +99,9 @@ abstract contract CreateAMM is ConstantProductFactoryTestHarness {
             appData: appData
         });
         vm.expectEmit();
-        emit ConstantProductFactory.TradingEnabled(ConstantProduct(expectedAMM), address(this));
+        emit ConstantProductFactory.Deployed(
+            ConstantProduct(expectedAMM), address(this), mockableToken0, mockableToken1
+        );
         vm.expectEmit();
         emit ComposableCoW.ConditionalOrderCreated(
             expectedAMM,

--- a/test/ConstantProductFactory/DisableTrading.sol
+++ b/test/ConstantProductFactory/DisableTrading.sol
@@ -28,7 +28,7 @@ abstract contract DisableTrading is ConstantProductFactoryTestHarness {
         ConstantProduct amm = setupAndCreateAMM();
 
         vm.expectEmit();
-        emit ConstantProductFactory.TradingDisabled(amm, address(this));
+        emit ConstantProductFactory.TradingDisabled(amm);
         constantProductFactory.disableTrading(amm);
     }
 

--- a/test/ConstantProductFactory/UpdateParameters.sol
+++ b/test/ConstantProductFactory/UpdateParameters.sol
@@ -58,9 +58,7 @@ abstract contract UpdateParameters is ConstantProductFactoryTestHarness {
         });
 
         vm.expectEmit();
-        emit ConstantProductFactory.TradingDisabled(amm, address(this));
-        vm.expectEmit();
-        emit ConstantProductFactory.TradingEnabled(amm, address(this));
+        emit ConstantProductFactory.TradingDisabled(amm);
         vm.expectEmit();
         emit ComposableCoW.ConditionalOrderCreated(
             address(amm),


### PR DESCRIPTION
This PR updates the documentation for solvers to index and use CoW AMM.
For practicality the emitted events have been changed so that a solver can get all information it needs by subscribing to the events of the factory, without having to query the AMM. The changes are:
- Every time a new AMM is deployed, a new event `Deployed` is fired, containing all useful immutable parameters.
- The event `TradingEnabled` has been removed, since it duplicates the event `ConditionalOrderCreated`.
- The event `TradingDisabled` has only the AMM address as its parameter.

### How to test

Updated unit tests.