### PR TITLE
Remove unused local vars

### DIFF
--- a/test/oracles/ChainlinkPriceOracle.sol
+++ b/test/oracles/ChainlinkPriceOracle.sol
@@ -107,8 +107,7 @@ contract ChainlinkPriceOracleTest is Test {
                 IWatchtowerCustomErrors.PollTryAtEpoch.selector, block.timestamp + 1 days, "stale oracle"
             )
         );
-        (uint256 priceNumerator, uint256 priceDenominator) =
-            oracle.getPrice(USDC, WETH, abi.encode(getDefaultOracleData()));
+        oracle.getPrice(USDC, WETH, abi.encode(getDefaultOracleData()));
     }
 
     function testRevertsIfOneOracleIsStale() public {


### PR DESCRIPTION
Removes unused local variables in the `ChainlinkPriceOracleTest` that were introduced in #57 resulting in compiler warnings. 

### How to test

CI.