### PR TITLE
Add UniswapV3 and Pyth oracles

### DIFF
--- a/src/interfaces/IPyth.sol
+++ b/src/interfaces/IPyth.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity ^0.8.0;
+
+/**
+ * @title Consume prices from the Pyth Network (https://pyth.network/).
+ * @author Pyth Data Association
+ * @dev This is an abridged version of the IPyth interface that can be found at:
+ * <https://github.com/pyth-network/pyth-sdk-solidity/blob/c24b3e0173a5715c875ae035c20e063cb900f481/IPyth.sol>
+ * All code is copied from that link except:
+ *  - Autoformatting.
+ *  - PythStructs importing.
+ */
+contract PythStructs {
+    // A price with a degree of uncertainty, represented as a price +- a confidence interval.
+    //
+    // The confidence interval roughly corresponds to the standard error of a normal distribution.
+    // Both the price and confidence are stored in a fixed-point numeric representation,
+    // `x * (10^expo)`, where `expo` is the exponent.
+    //
+    // Please refer to the documentation at https://docs.pyth.network/consumers/best-practices for how
+    // to how this price safely.
+    struct Price {
+        // Price
+        int64 price;
+        // Confidence interval around the price
+        uint64 conf;
+        // Price exponent
+        int32 expo;
+        // Unix timestamp describing when the price was published
+        uint256 publishTime;
+    }
+}
+
+interface IPyth {
+    /// @notice Returns the price of a price feed without any sanity checks.
+    /// @dev This function returns the most recent price update in this contract without any recency checks.
+    /// This function is unsafe as the returned price update may be arbitrarily far in the past.
+    ///
+    /// Users of this function should check the `publishTime` in the price to ensure that the returned price is
+    /// sufficiently recent for their application. If you are considering using this function, it may be
+    /// safer / easier to use either `getPrice` or `getPriceNoOlderThan`.
+    /// @return price - please read the documentation of PythStructs.Price to understand how to use this safely.
+    function getPriceUnsafe(bytes32 id) external view returns (PythStructs.Price memory price);
+}

--- a/src/interfaces/IUniswapV3Pool.sol
+++ b/src/interfaces/IUniswapV3Pool.sol
@@ -1,0 +1,46 @@
+// SPDX-License-Identifier: GPL-2.0-or-later
+pragma solidity >=0.5.0;
+
+/**
+ * @title The interface for a Uniswap V3 Pool
+ * @author Uniswap developers
+ * @dev This is an abridged version of the Uniswap V3 Pool interface that can be found at:
+ * <https://github.com/Uniswap/v3-core/blob/d8b1c635c275d2a9450bd6a78f3fa2484fef73eb/contracts/interfaces/IUniswapV3Pool.sol>
+ * All code is copied from that link except:
+ *  - Autoformatting.
+ */
+interface IUniswapV3Pool {
+    /// @notice The first of the two tokens of the pool, sorted by address
+    /// @return The token contract address
+    function token0() external view returns (address);
+
+    /// @notice The second of the two tokens of the pool, sorted by address
+    /// @return The token contract address
+    function token1() external view returns (address);
+
+    /// @notice The 0th storage slot in the pool stores many values, and is exposed as a single method to save gas
+    /// when accessed externally.
+    /// @return sqrtPriceX96 The current price of the pool as a sqrt(token1/token0) Q64.96 value
+    /// tick The current tick of the pool, i.e. according to the last tick transition that was run.
+    /// This value may not always be equal to SqrtTickMath.getTickAtSqrtRatio(sqrtPriceX96) if the price is on a tick
+    /// boundary.
+    /// observationIndex The index of the last oracle observation that was written,
+    /// observationCardinality The current maximum number of observations stored in the pool,
+    /// observationCardinalityNext The next maximum number of observations, to be updated when the observation.
+    /// feeProtocol The protocol fee for both tokens of the pool.
+    /// Encoded as two 4 bit values, where the protocol fee of token1 is shifted 4 bits and the protocol fee of token0
+    /// is the lower 4 bits. Used as the denominator of a fraction of the swap fee, e.g. 4 means 1/4th of the swap fee.
+    /// unlocked Whether the pool is currently locked to reentrancy
+    function slot0()
+        external
+        view
+        returns (
+            uint160 sqrtPriceX96,
+            int24 tick,
+            uint16 observationIndex,
+            uint16 observationCardinality,
+            uint16 observationCardinalityNext,
+            uint8 feeProtocol,
+            bool unlocked
+        );
+}

--- a/src/oracles/PythPriceOracle.sol
+++ b/src/oracles/PythPriceOracle.sol
@@ -1,0 +1,93 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.24;
+
+import {Math} from "lib/openzeppelin/contracts/utils/math/Math.sol";
+import {stdMath} from "lib/openzeppelin/lib/forge-std/src/StdMath.sol";
+import {IPriceOracle} from "../interfaces/IPriceOracle.sol";
+import {IConditionalOrder} from "lib/composable-cow/src/interfaces/IConditionalOrder.sol";
+import {IWatchtowerCustomErrors} from "../interfaces/IWatchtowerCustomErrors.sol";
+import {IPyth, PythStructs} from "../interfaces/IPyth.sol";
+
+/**
+ * @title Pyth Price Oracle
+ * @author yvesfracari
+ * @dev This contract creates an oracle that is compatible with the IPriceOracle
+ * interface and can be used by a CoW AMM to determine the current price of the
+ * traded tokens from Pyth Data Feeds with decimals lower or equal to 18.
+ */
+contract PythPriceOracle is IPriceOracle, IWatchtowerCustomErrors {
+    /**
+     * @notice The Pyth entrypoint on the network
+     */
+    IPyth public pythAggregator;
+    uint256 private constant _MAX_BPS = 10000;
+
+    /**
+     * @param token0Feed Id of token0 price feed
+     * @param token1Feed Id of token1 price feed
+     * @param minPrecisionBps Minimum precision considering (price-error)/price in bases points
+     * @param timeThreshold Amount of seconds before the oracle is considered stale
+     * @param backoff Duration to indicate how long the watchtower should wait for the oracle to refresh
+     */
+    struct Data {
+        bytes32 token0Feed;
+        bytes32 token1Feed;
+        uint256 minPrecisionBps;
+        uint256 timeThreshold;
+        uint256 backoff;
+    }
+
+    /**
+     * @param _pythAggregator The address of the Pyth aggregator in the current chain.
+     */
+    constructor(IPyth _pythAggregator) {
+        pythAggregator = _pythAggregator;
+    }
+
+    /**
+     * @dev There is no mapping between Pyth oracle and the token address,
+     * so the user must check that the oracle corresponds to the token themselves.
+     * @inheritdoc IPriceOracle
+     */
+    function getPrice(address, address, bytes calldata data)
+        external
+        view
+        returns (uint256 priceNumerator, uint256 priceDenominator)
+    {
+        Data memory oracleData = abi.decode(data, (Data));
+
+        PythStructs.Price memory price0 = pythAggregator.getPriceUnsafe(oracleData.token0Feed);
+        PythStructs.Price memory price1 = pythAggregator.getPriceUnsafe(oracleData.token1Feed);
+
+        uint256 minPublishTime = block.timestamp - oracleData.timeThreshold;
+
+        if (price0.price < 0 || price1.price < 0) {
+            revert IConditionalOrder.OrderNotValid("negative price");
+        }
+
+        if (price0.expo > 0 || price1.expo > 0 || price0.expo < -18 || price1.expo < -18) {
+            revert IConditionalOrder.OrderNotValid("unsupported decimals");
+        }
+
+        if (minPublishTime > price0.publishTime || minPublishTime > price1.publishTime) {
+            revert PollTryAtEpoch(block.timestamp + oracleData.backoff, "stale oracle");
+        }
+
+        uint256 price0Uint256 = stdMath.abs(int256(price0.price));
+        uint256 price1Uint256 = stdMath.abs(int256(price1.price));
+
+        uint256 price0PrecisionBps = Math.mulDiv(price0Uint256 - uint256(price0.conf), _MAX_BPS, price0Uint256);
+        uint256 price1PrecisionBps = Math.mulDiv(price1Uint256 - uint256(price1.conf), _MAX_BPS, price1Uint256);
+        if (price0PrecisionBps < oracleData.minPrecisionBps || price1PrecisionBps < oracleData.minPrecisionBps) {
+            revert PollTryAtEpoch(block.timestamp + oracleData.backoff, "imprecise oracle");
+        }
+
+        if (price0.expo == price1.expo) {
+            priceNumerator = price1Uint256;
+            priceDenominator = price0Uint256;
+        } else {
+            priceNumerator = price1Uint256 * (10 ** (18 - stdMath.abs(int256(price1.expo))));
+            priceDenominator = price0Uint256 * (10 ** (18 - stdMath.abs(int256(price0.expo))));
+        }
+    }
+}

--- a/src/oracles/UniswapV3PriceOracle.sol
+++ b/src/oracles/UniswapV3PriceOracle.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.24;
+
+import {IERC20} from "lib/forge-std/src/interfaces/IERC20.sol";
+import {Math} from "lib/openzeppelin/contracts/utils/math/Math.sol";
+
+import {IPriceOracle} from "../interfaces/IPriceOracle.sol";
+import {IUniswapV3Pool} from "../interfaces/IUniswapV3Pool.sol";
+
+/**
+ * @title CoW AMM UniswapV3 Price Oracle
+ * @author yvesfracari
+ * @dev This contract creates an oracle that is compatible with the IPriceOracle
+ * interface and can be used by a CoW AMM to determine the current price of the
+ * traded tokens on specific Uniswap v3 pools.
+ */
+contract UniswapV3PriceOracle is IPriceOracle {
+    /**
+     * Data required by the oracle to determine the current price.
+     */
+    struct Data {
+        /**
+         * The Uniswap v3 pool to use as a price reference.
+         * It is expected that the pool's token0 and token1 coincide with the
+         * tokens traded by the AMM and have the same order.
+         */
+        IUniswapV3Pool referencePool;
+    }
+
+    /**
+     * @inheritdoc IPriceOracle
+     */
+    function getPrice(address token0, address token1, bytes calldata data)
+        external
+        view
+        returns (uint256 priceNumerator, uint256 priceDenominator)
+    {
+        Data memory oracleData = abi.decode(data, (Data));
+        (uint160 sqrtPriceX96,,,,,,) = oracleData.referencePool.slot0();
+        IERC20 uniswapToken0 = IERC20(oracleData.referencePool.token0());
+        IERC20 uniswapToken1 = IERC20(oracleData.referencePool.token1());
+        uint8 token0Decimals = uniswapToken0.decimals();
+        uint8 token1Decimals = uniswapToken1.decimals();
+
+        // From UniswapV3 Docs: price=(sqrtPriceX96/2^96)ˆ2
+        uint256 price = Math.mulDiv(uint256(sqrtPriceX96), uint256(sqrtPriceX96), 4 ** 96);
+        priceNumerator = Math.mulDiv(price, 10 ** token0Decimals, 1);
+        priceDenominator = 10 ** token1Decimals;
+
+        if (token0 == address(uniswapToken1)) {
+            (priceNumerator, priceDenominator) = (priceDenominator, priceNumerator);
+            (uniswapToken0, uniswapToken1) = (uniswapToken1, uniswapToken0);
+        }
+        require(token0 == address(uniswapToken0), "oracle: invalid token0");
+        require(token1 == address(uniswapToken1), "oracle: invalid token1");
+    }
+}

--- a/test/oracles/PythPriceOracle.sol
+++ b/test/oracles/PythPriceOracle.sol
@@ -1,0 +1,137 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.24;
+
+import {Test, console2} from "forge-std/Test.sol";
+
+import {PythPriceOracle, IPyth, IWatchtowerCustomErrors, IConditionalOrder} from "src/oracles/PythPriceOracle.sol";
+
+contract PythPriceOracleTest is Test {
+    address private unusedToken = makeAddr("unused token");
+    bytes32 private USDCOracle = keccak256("USDC Oracle");
+    bytes32 private WETHOracle = keccak256("WETH Oracle");
+
+    PythPriceOracle internal oracle;
+    IPyth internal oracleAggregator;
+    uint256 private defaultMinOraclePrecision = 5000;
+    uint256 private defaultTimeThreshold = 1000;
+    uint256 private defaultBackoff = 1;
+
+    uint256 currentTimestamp = 10000;
+
+    function setUp() public {
+        oracle = new PythPriceOracle(oracleAggregator);
+        vm.warp(currentTimestamp);
+
+        vm.mockCall(
+            address(oracleAggregator),
+            abi.encodeCall(IPyth.getPriceUnsafe, (USDCOracle)),
+            abi.encode(int64(1e8), uint64(1e4), -8, currentTimestamp - 1)
+        );
+        vm.mockCall(
+            address(oracleAggregator),
+            abi.encodeCall(IPyth.getPriceUnsafe, (WETHOracle)),
+            abi.encode(int64(3000e8), uint64(1e4), -8, currentTimestamp - 1)
+        );
+    }
+
+    function getDefaultOracleData() internal view returns (PythPriceOracle.Data memory data) {
+        data = PythPriceOracle.Data({
+            token0Feed: USDCOracle,
+            token1Feed: WETHOracle,
+            minPrecisionBps: defaultMinOraclePrecision,
+            timeThreshold: defaultTimeThreshold,
+            backoff: defaultBackoff
+        });
+    }
+
+    function testReturnsExpectedPrice() public {
+        (uint256 priceNumerator, uint256 priceDenominator) =
+            oracle.getPrice(unusedToken, unusedToken, abi.encode(getDefaultOracleData()));
+        assertEq(priceNumerator, 3000e8);
+        assertEq(priceDenominator, 1e8);
+    }
+
+    function testReturnsInvertedPrice() public {
+        (uint256 priceNumerator, uint256 priceDenominator) = oracle.getPrice(
+            unusedToken,
+            unusedToken,
+            abi.encode(
+                PythPriceOracle.Data({
+                    token0Feed: WETHOracle,
+                    token1Feed: USDCOracle,
+                    minPrecisionBps: defaultMinOraclePrecision,
+                    timeThreshold: defaultTimeThreshold,
+                    backoff: defaultBackoff
+                })
+            )
+        );
+        assertEq(priceNumerator, 1e8);
+        assertEq(priceDenominator, 3000e8);
+    }
+
+    function testNormalizedDecimals() public {
+        vm.mockCall(
+            address(oracleAggregator),
+            abi.encodeCall(IPyth.getPriceUnsafe, (WETHOracle)),
+            abi.encode(int64(3000e9), uint64(1e4), -9, currentTimestamp - 1)
+        );
+        (uint256 priceNumerator, uint256 priceDenominator) =
+            oracle.getPrice(unusedToken, unusedToken, abi.encode(getDefaultOracleData()));
+        assertEq(priceNumerator, 3000e18);
+        assertEq(priceDenominator, 1e18);
+    }
+
+    function testRevertsDecimalsAboveLimit() public {
+        vm.mockCall(
+            address(oracleAggregator),
+            abi.encodeCall(IPyth.getPriceUnsafe, (USDCOracle)),
+            abi.encode(int64(1e18), uint64(1e6), -19, currentTimestamp - 1)
+        );
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, "unsupported decimals"));
+        oracle.getPrice(unusedToken, unusedToken, abi.encode(getDefaultOracleData()));
+    }
+
+    function testRevertsNegativeDecimalsLimit() public {
+        vm.mockCall(
+            address(oracleAggregator),
+            abi.encodeCall(IPyth.getPriceUnsafe, (USDCOracle)),
+            abi.encode(int64(1e18), uint64(1e6), 1, currentTimestamp - 1)
+        );
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, "unsupported decimals"));
+        oracle.getPrice(unusedToken, unusedToken, abi.encode(getDefaultOracleData()));
+    }
+
+    function testRevertsIfOracleIsStale() public {
+        vm.warp(currentTimestamp + defaultTimeThreshold + 1);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IWatchtowerCustomErrors.PollTryAtEpoch.selector, block.timestamp + defaultBackoff, "stale oracle"
+            )
+        );
+        oracle.getPrice(unusedToken, unusedToken, abi.encode(getDefaultOracleData()));
+    }
+
+    function testRevertsIfPriceIsNegative() public {
+        vm.mockCall(
+            address(oracleAggregator),
+            abi.encodeCall(IPyth.getPriceUnsafe, (USDCOracle)),
+            abi.encode(int64(-1e8), uint64(1e6), -6, currentTimestamp - 1)
+        );
+        vm.expectRevert(abi.encodeWithSelector(IConditionalOrder.OrderNotValid.selector, "negative price"));
+        oracle.getPrice(unusedToken, unusedToken, abi.encode(getDefaultOracleData()));
+    }
+
+    function testRevertsIfOracleIsImprecise() public {
+        vm.mockCall(
+            address(oracleAggregator),
+            abi.encodeCall(IPyth.getPriceUnsafe, (USDCOracle)),
+            abi.encode(int64(1e8), uint64(6e7), -6, currentTimestamp - 1)
+        );
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                IWatchtowerCustomErrors.PollTryAtEpoch.selector, block.timestamp + defaultBackoff, "imprecise oracle"
+            )
+        );
+        oracle.getPrice(unusedToken, unusedToken, abi.encode(getDefaultOracleData()));
+    }
+}

--- a/test/oracles/UniswapV3PriceOracle.sol
+++ b/test/oracles/UniswapV3PriceOracle.sol
@@ -1,0 +1,83 @@
+// SPDX-License-Identifier: GPL-3.0
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+
+import {UniswapV3PriceOracle, IUniswapV3Pool, IERC20} from "src/oracles/UniswapV3PriceOracle.sol";
+
+contract UniswapV3PriceOracleTest is Test {
+    address private token0 = makeAddr("X");
+    address private token1 = makeAddr("Y");
+    address private DEFAULT_PAIR = makeAddr("default token0/token1 pool");
+    uint160 private constant sqrtPriceX96 = 3000 * (2 ** 96);
+    uint256 private constant price = 3000 ** 2;
+    uint8 private constant token0Decimals = 8;
+    uint8 private constant token1Decimals = 18;
+
+    UniswapV3PriceOracle internal oracle;
+    IUniswapV3Pool internal pool;
+
+    function setUp() public {
+        oracle = new UniswapV3PriceOracle();
+
+        pool = IUniswapV3Pool(DEFAULT_PAIR);
+
+        vm.mockCall(address(pool), abi.encodeCall(IUniswapV3Pool.token0, ()), abi.encode(token0));
+        vm.mockCall(address(pool), abi.encodeCall(IUniswapV3Pool.token1, ()), abi.encode(token1));
+        vm.mockCall(address(token0), abi.encodeCall(IERC20.decimals, ()), abi.encode(token0Decimals));
+        vm.mockCall(address(token1), abi.encodeCall(IERC20.decimals, ()), abi.encode(token1Decimals));
+
+        int24 tick = 0;
+        uint16 unusedObservationIndex = 0;
+        uint16 unusedObservationCardinality = 0;
+        uint16 unusedObservationCardinalityNext = 0;
+        uint8 unusedFeeProtocol = 0;
+        bool unusedUnlocked = true;
+        vm.mockCall(
+            address(DEFAULT_PAIR),
+            abi.encodeCall(IUniswapV3Pool.slot0, ()),
+            abi.encode(
+                sqrtPriceX96,
+                tick,
+                unusedObservationIndex,
+                unusedObservationCardinality,
+                unusedObservationCardinalityNext,
+                unusedFeeProtocol,
+                unusedUnlocked
+            )
+        );
+    }
+
+    function getDefaultOracleData() internal view returns (UniswapV3PriceOracle.Data memory data) {
+        data = UniswapV3PriceOracle.Data(pool);
+    }
+
+    function testReturnsExpectedPrice() public {
+        (uint256 priceNumerator, uint256 priceDenominator) =
+            oracle.getPrice(token0, token1, abi.encode(getDefaultOracleData()));
+        assertEq(priceNumerator, price * (10 ** token0Decimals));
+        assertEq(priceDenominator, 10 ** token1Decimals);
+    }
+
+    function testInvertsPriceIfTokensAreInverted() public {
+        (uint256 priceNumerator, uint256 priceDenominator) =
+            oracle.getPrice(token1, token0, abi.encode(getDefaultOracleData()));
+        assertEq(priceNumerator, 10 ** token1Decimals);
+        assertEq(priceDenominator, price * (10 ** token0Decimals));
+    }
+
+    function testRevertsIfPairUsesIncorrectToken0() public {
+        vm.expectRevert("oracle: invalid token0");
+        oracle.getPrice(makeAddr("bad token 0"), token1, abi.encode(getDefaultOracleData()));
+    }
+
+    function testRevertsIfPairUsesIncorrectToken1() public {
+        vm.expectRevert("oracle: invalid token1");
+        oracle.getPrice(token0, makeAddr("bad token 1"), abi.encode(getDefaultOracleData()));
+    }
+
+    function testRevertsIfPairUsesIncorrectTokenWhenInverted() public {
+        vm.expectRevert("oracle: invalid token0");
+        oracle.getPrice(makeAddr("bad token 1"), token0, abi.encode(getDefaultOracleData()));
+    }
+}


### PR DESCRIPTION
This PR is dedicated to adding Pyth and UniswapV3 price oracles contracts. Each oracle has its own tests to validate the desired behavior. 

How To Test: Run the automated tests for each oracle.
