### PR TITLE
chore: constant product helper

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -8,7 +8,6 @@ optimizer = true
 optimizer_runs = 100_000
 
 remappings = [
-  "lib/composable-cow:cowprotocol/=lib/composable-cow/lib/cowprotocol/src/contracts/",
   "lib/composable-cow:safe/=lib/composable-cow/lib/safe/contracts/",
   "lib/composable-cow:@openzeppelin/=lib/openzeppelin/contracts/",
   "lib/composable-cow:@openzeppelin/contracts/=lib/openzeppelin/contracts/",

--- a/src/ConstantProduct.sol
+++ b/src/ConstantProduct.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: GPL-3.0
 pragma solidity ^0.8.24;
 
-import {IERC20} from "lib/openzeppelin/contracts/interfaces/IERC20.sol";
+import {IERC20 as OZIERC20} from "lib/openzeppelin/contracts/interfaces/IERC20.sol";
 import {IERC1271} from "lib/openzeppelin/contracts/interfaces/IERC1271.sol";
 import {SafeERC20} from "lib/openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import {Math} from "lib/openzeppelin/contracts/utils/math/Math.sol";
 import {ConditionalOrdersUtilsLib as Utils} from "lib/composable-cow/src/types/ConditionalOrdersUtilsLib.sol";
-import {IConditionalOrder, GPv2Order} from "lib/composable-cow/src/BaseConditionalOrder.sol";
+import {IConditionalOrder, GPv2Order, IERC20} from "lib/composable-cow/src/BaseConditionalOrder.sol";
 
 import {IPriceOracle} from "./interfaces/IPriceOracle.sol";
 import {ISettlement} from "./interfaces/ISettlement.sol";
@@ -21,7 +21,7 @@ import {IWatchtowerCustomErrors} from "./interfaces/IWatchtowerCustomErrors.sol"
  * Order creation and execution is based on the Composable CoW base contracts.
  */
 contract ConstantProduct is IERC1271 {
-    using SafeERC20 for IERC20;
+    using SafeERC20 for OZIERC20;
     using GPv2Order for GPv2Order.Data;
 
     /// All data used by an order to validate the AMM conditions.
@@ -383,7 +383,7 @@ contract ConstantProduct is IERC1271 {
      * @param spender The address that can transfer on behalf of this contract.
      */
     function approveUnlimited(IERC20 token, address spender) internal {
-        token.safeApprove(spender, type(uint256).max);
+        OZIERC20(address(token)).safeApprove(spender, type(uint256).max);
     }
 
     /**

--- a/src/ConstantProductFactory.sol
+++ b/src/ConstantProductFactory.sol
@@ -4,7 +4,7 @@ pragma solidity ^0.8.24;
 import {ComposableCoW, IConditionalOrder} from "lib/composable-cow/src/ComposableCoW.sol";
 import {SafeERC20} from "lib/openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
-import {ConstantProduct, IERC20, ISettlement, GPv2Order, IPriceOracle} from "./ConstantProduct.sol";
+import {ConstantProduct, IERC20, OZIERC20, ISettlement, GPv2Order, IPriceOracle} from "./ConstantProduct.sol";
 
 /**
  * @title CoW AMM Factory
@@ -15,7 +15,7 @@ import {ConstantProduct, IERC20, ISettlement, GPv2Order, IPriceOracle} from "./C
  * enabling/disabling trading and updating trade parameters.
  */
 contract ConstantProductFactory {
-    using SafeERC20 for IERC20;
+    using SafeERC20 for OZIERC20;
 
     /**
      * @notice The settlement contract for CoW Protocol on this network.
@@ -147,8 +147,8 @@ contract ConstantProductFactory {
      * @param amount1 amount of AMM's token1 to withdraw
      */
     function withdraw(ConstantProduct amm, uint256 amount0, uint256 amount1) external onlyOwner(amm) {
-        amm.token0().safeTransferFrom(address(amm), msg.sender, amount0);
-        amm.token1().safeTransferFrom(address(amm), msg.sender, amount1);
+        OZIERC20(address(amm.token0())).safeTransferFrom(address(amm), msg.sender, amount0);
+        OZIERC20(address(amm.token1())).safeTransferFrom(address(amm), msg.sender, amount1);
     }
 
     /**
@@ -237,8 +237,8 @@ contract ConstantProductFactory {
      * @param amount1 amount of AMM's token1 to deposit
      */
     function deposit(ConstantProduct amm, uint256 amount0, uint256 amount1) public {
-        amm.token0().safeTransferFrom(msg.sender, address(amm), amount0);
-        amm.token1().safeTransferFrom(msg.sender, address(amm), amount1);
+        OZIERC20(address(amm.token0())).safeTransferFrom(msg.sender, address(amm), amount0);
+        OZIERC20(address(amm.token1())).safeTransferFrom(msg.sender, address(amm), amount1);
     }
 
     /**

--- a/src/ConstantProductHelper.sol
+++ b/src/ConstantProductHelper.sol
@@ -38,7 +38,7 @@ contract ConstantProductHelper is IPriceOracle {
      * @returns The GPv2Order.Data struct for the CoW Protocol JIT order and
      * it's associated ERC-1271 signature.
      */
-    function order(ConstantProduct pool, uint256 numerator, uint256 denominator, bytes calldata data)
+    function getOrder(ConstantProduct pool, uint256 numerator, uint256 denominator, bytes calldata data)
         external
         view
         returns (GPv2Order.Data memory, bytes memory)
@@ -57,8 +57,8 @@ contract ConstantProductHelper is IPriceOracle {
             appData: params.appData
         });
 
-        GPv2Order.Data memory returnedOrder = pool.getTradeableOrder(spoofParams);
-        return (pool.getTradeableOrder(spoof), abi.encode(returnedOrder, params));
+        GPv2Order.Data memory order = pool.getOrder(spoof);
+        return (order, abi.encode(order, params));
     }
 
     function getPrice(address, address, bytes calldata)

--- a/src/ConstantProductHelper.sol
+++ b/src/ConstantProductHelper.sol
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: LGPL-3.0-only
+pragma solidity ^0.8.24;
+
+import {IERC20} from "lib/openzeppelin/contracts/interfaces/IERC20.sol";
+import {GPv2Order} from "lib/composable-cow/src/BaseConditionalOrder.sol";
+import {ConstantProduct} from "./ConstantProduct.sol";
+import {IPriceOracle} from "./interfaces/IPriceOracle.sol";
+
+contract ConstantProductHelper is IPriceOracle {
+    bytes32 public constant NUMERATOR_SLOT = keccak256("ConstantProductHelper.numerator");
+    bytes32 public constant DENOMINATOR_SLOT = keccak256("ConstantProductHelper.denominator");
+
+    function events() external view returns (bytes32 createPool, bytes32 enablePool, bytes32 disablePool) {
+        return (
+            bytes32(keccak256("Deployed(address,address,address,address)")),
+            bytes32(keccak256("TradingEnabled(bytes32,(uint256,address,bytes,bytes32))")),
+            bytes32(keccak256("TradingDisabled()"))
+        );
+    }
+
+    /**
+     * CoW AMM Pool helpers MUST return all tokens that may be traded on this pool
+     */
+    function tokens(ConstantProduct pool) external view returns (IERC20[] memory) {
+        return [pool.token0(), pool.token1()];
+    }
+
+    /**
+     * CoW AMM Pool helpers MUST provide a method for returning the canonical order
+     * required to satisfy the pool's invariants, given a pricing vector, and
+     * arbitrary data.
+     * @param pool to calculate the order / signature for
+     * @param numerator of the price vector
+     * @param denominator of the price vector
+     * @param data of arbitrary nature that may have been returned from
+     * the 2nd argument to the pool enabling event. If arbitrary data isn't
+     * supplied, supply `hex''`
+     * @returns The GPv2Order.Data struct for the CoW Protocol JIT order and
+     * it's associated ERC-1271 signature.
+     */
+    function order(ConstantProduct pool, uint256 numerator, uint256 denominator, bytes calldata data)
+        external
+        view
+        returns (GPv2Order.Data memory, bytes memory)
+    {
+        assembly ("memory-safe") {
+            // Store the numerator and denominator in the slot
+            tstore(NUMERATOR_SLOT, numerator)
+            tstore(DENOMINATOR_SLOT, denominator)
+        }
+
+        ConstantProduct.TradingParams memory params = abi.decode(data, (ConstantProduct.TradingParams));
+        ConstantProduct.TradingParams memory spoof = ConstantProduct.TradingParams({
+            minTradedToken0: 0,
+            priceOracle: address(this),
+            priceOracleData: hex"",
+            appData: params.appData
+        });
+
+        GPv2Order.Data memory returnedOrder = pool.getTradeableOrder(spoofParams);
+        return (pool.getTradeableOrder(spoof), abi.encode(returnedOrder, params));
+    }
+
+    function getPrice(address, address, bytes calldata)
+        external
+        view
+        returns (uint256 priceNumerator, uint256 priceDenominator)
+    {
+        assembly ("memory-safe") {
+            priceNumerator := tload(NUMERATOR_SLOT)
+            priceDenominator := tload(DENOMINATOR_SLOT)
+        }
+    }
+}

--- a/src/ConstantProductHelper.sol
+++ b/src/ConstantProductHelper.sol
@@ -1,16 +1,17 @@
 // SPDX-License-Identifier: LGPL-3.0-only
 pragma solidity ^0.8.24;
 
-import {IERC20} from "lib/openzeppelin/contracts/interfaces/IERC20.sol";
-import {GPv2Order} from "lib/composable-cow/src/BaseConditionalOrder.sol";
+import {IERC20, GPv2Order} from "lib/composable-cow/src/BaseConditionalOrder.sol";
 import {ConstantProduct} from "./ConstantProduct.sol";
 import {IPriceOracle} from "./interfaces/IPriceOracle.sol";
 
 contract ConstantProductHelper is IPriceOracle {
-    bytes32 public constant NUMERATOR_SLOT = keccak256("ConstantProductHelper.numerator");
-    bytes32 public constant DENOMINATOR_SLOT = keccak256("ConstantProductHelper.denominator");
+    // uint256(keccak256("ConstantProductHelper.numerator")) - 1
+    uint256 public constant NUMERATOR_SLOT = 0x223dcd62dbf383e930e6aa5d74a39264cb580dbc29ee32ecbfc9edd7179ff604;
+    // uint256(keccak256("ConstantProductHelper.denominator")) - 1
+    uint256 public constant DENOMINATOR_SLOT = 0x30843a766054dd7fc4b0ac76c32c0a5da91a64e646d782e95f94d37ff51d4178;
 
-    function events() external view returns (bytes32 createPool, bytes32 enablePool, bytes32 disablePool) {
+    function events() external pure returns (bytes32 createPool, bytes32 enablePool, bytes32 disablePool) {
         return (
             bytes32(keccak256("Deployed(address,address,address,address)")),
             bytes32(keccak256("TradingEnabled(bytes32,(uint256,address,bytes,bytes32))")),
@@ -21,8 +22,11 @@ contract ConstantProductHelper is IPriceOracle {
     /**
      * CoW AMM Pool helpers MUST return all tokens that may be traded on this pool
      */
-    function tokens(ConstantProduct pool) external view returns (IERC20[] memory) {
-        return [pool.token0(), pool.token1()];
+    function tokens(ConstantProduct pool) external view returns (IERC20[] memory tokens_) {
+        tokens_ = new IERC20[](2);
+        tokens_[0] = IERC20(pool.token0());
+        tokens_[1] = IERC20(pool.token1());
+        return tokens_;
     }
 
     /**
@@ -35,14 +39,13 @@ contract ConstantProductHelper is IPriceOracle {
      * @param data of arbitrary nature that may have been returned from
      * the 2nd argument to the pool enabling event. If arbitrary data isn't
      * supplied, supply `hex''`
-     * @returns The GPv2Order.Data struct for the CoW Protocol JIT order and
+     * @return The GPv2Order.Data struct for the CoW Protocol JIT order and
      * it's associated ERC-1271 signature.
      */
     function getOrder(ConstantProduct pool, uint256 numerator, uint256 denominator, bytes calldata data)
         external
-        view
         returns (GPv2Order.Data memory, bytes memory)
-    {
+    {        
         assembly ("memory-safe") {
             // Store the numerator and denominator in the slot
             tstore(NUMERATOR_SLOT, numerator)
@@ -52,12 +55,12 @@ contract ConstantProductHelper is IPriceOracle {
         ConstantProduct.TradingParams memory params = abi.decode(data, (ConstantProduct.TradingParams));
         ConstantProduct.TradingParams memory spoof = ConstantProduct.TradingParams({
             minTradedToken0: 0,
-            priceOracle: address(this),
+            priceOracle: IPriceOracle(address(this)),
             priceOracleData: hex"",
             appData: params.appData
         });
 
-        GPv2Order.Data memory order = pool.getOrder(spoof);
+        GPv2Order.Data memory order = pool.getTradeableOrder(spoof);
         return (order, abi.encode(order, params));
     }
 


### PR DESCRIPTION
This PR: 

1. Provides a helper for use by backend that exposes the math available within `ConstantProduct` so as to generate orders that respect the invariant.