### PR TITLE
fix: account for inverse price order of price oracle

### DIFF
--- a/src/ConstantProductHelper.sol
+++ b/src/ConstantProductHelper.sol
@@ -84,8 +84,11 @@ contract ConstantProductHelper is ICOWAMMPoolHelper, LegacyHelper {
                     pool: pool,
                     token0: token0,
                     token1: token1,
-                    priceNumerator: prices[0],
-                    priceDenominator: prices[1],
+                    // The price of this function is expressed as amount of
+                    // token1 per amount of token0. The `prices` vector is
+                    // expressed the other way around.
+                    priceNumerator: prices[1],
+                    priceDenominator: prices[0],
                     appData: ConstantProduct(pool).APP_DATA()
                 })
             );

--- a/src/interfaces/ICOWAMMPoolHelper.sol
+++ b/src/interfaces/ICOWAMMPoolHelper.sol
@@ -53,7 +53,15 @@ interface ICOWAMMPoolHelper {
      *      given price vector.
      * @param pool to calculate the order / signature for
      * @param prices supplied for determining the order, assumed to be in the
-     *        same order as returned from `tokens(pool)`.
+     *        same order as returned from `tokens(pool)`. Tokens prices are
+     *        expressed relative to each other: for example, if tokens[0] is
+     *        WETH, tokens[2] is DAI, and the price is 1 WETH per 3000 DAI, then
+     *        a valid price vector is [3000, *, 1, ...]. If tokens[1] is another
+     *        stablecoin with 18 decimals, then a valid price vector could be
+     *        [3000, 3000, 1, ...].
+     *        This price vector is compatible with the price vector used in a
+     *        call to `settle`, assuming the traded token array is in the same
+     *        order as in `tokens(pool)`.
      * @return order The CoW Protocol JIT order
      * @return preInteractions The array array for any **PRE** interactions (empty if none)
      * @return postInteractions The array array for any **POST** interactions (empty if none)

--- a/src/libraries/GetTradeableOrder.sol
+++ b/src/libraries/GetTradeableOrder.sol
@@ -10,7 +10,15 @@ library GetTradeableOrder {
         address pool;
         IERC20 token0;
         IERC20 token1;
+        /// @dev The numerator of the price, expressed in amount of token1 per
+        /// amount of token0. For example, if token0 is DAI and the price is
+        /// 1 WETH (token1) for 3000 DAI, then this could be 1 (and the
+        /// denominator would be 3000).
         uint256 priceNumerator;
+        /// @dev The denominator of the price, expressed in amount of token1 per
+        /// amount of token0. For example, if token0 is DAI and the price is
+        /// 1 WETH (token1) for 3000 DAI, then this could be 3000 (and the
+        /// denominator would be 1).
         uint256 priceDenominator;
         bytes32 appData;
     }


### PR DESCRIPTION
Issue noticed by @MartinquaXD that meant that orders returned by the interface would return wildly incorrect prices.

Here I add comments that clarify what the prices are and fix their usage accordingly.
I could have just inverted the meaning of "numerator" and "denominator" for consistency, but I preferred to keep this testing code as close as possible to the original implementation of an oracle to make it more easy to reason about with legacy code (for example in #83).

If approved I'll redeploy the contracts with this fix included.