### PR TITLE
fix: use inverse price order in legacy as well

### DIFF
--- a/src/legacy/Helper.sol
+++ b/src/legacy/Helper.sol
@@ -53,8 +53,11 @@ abstract contract Helper is Snapshot {
                 pool: pool,
                 token0: _tokens[0],
                 token1: _tokens[1],
-                priceNumerator: prices[0],
-                priceDenominator: prices[1],
+                // The price of this function is expressed as amount of
+                // token1 per amount of token0. The `prices` vector is
+                // expressed the other way around.
+                priceNumerator: prices[1],
+                priceDenominator: prices[0],
                 appData: tradingParams.appData
             })
         );


### PR DESCRIPTION
Unfortunately #87 isn't enough to fix the issue mentioned in the description: this is because `getTradeableOrder` is also used in the legacy math, where it wasn't updated.

Here the code is adjusted in the legacy path as well.

### How to test

Notice that `getTradeableOrder` is only used twice, and in both cases we changed the order of the price vector.