### PR TITLE
Update helper math

### DIFF
--- a/src/libraries/GetTradeableOrder.sol
+++ b/src/libraries/GetTradeableOrder.sol
@@ -58,23 +58,13 @@ library GetTradeableOrder {
             sellToken = params.token0;
             buyToken = params.token1;
             sellAmount = selfReserve0 / 2 - Math.ceilDiv(selfReserve1TimesPriceNumerator, 2 * params.priceDenominator);
-            buyAmount = Math.mulDiv(
-                sellAmount,
-                selfReserve1TimesPriceNumerator + (params.priceDenominator * sellAmount),
-                params.priceNumerator * selfReserve0,
-                Math.Rounding.Up
-            );
+            buyAmount = Math.mulDiv(sellAmount, selfReserve1, selfReserve0 - sellAmount, Math.Rounding.Up);
             tradedAmountToken0 = sellAmount;
         } else {
             sellToken = params.token1;
             buyToken = params.token0;
             sellAmount = selfReserve1 / 2 - Math.ceilDiv(selfReserve0TimesPriceDenominator, 2 * params.priceNumerator);
-            buyAmount = Math.mulDiv(
-                sellAmount,
-                selfReserve0TimesPriceDenominator + (params.priceNumerator * sellAmount),
-                params.priceDenominator * selfReserve1,
-                Math.Rounding.Up
-            );
+            buyAmount = Math.mulDiv(sellAmount, selfReserve0, selfReserve1 - sellAmount, Math.Rounding.Up);
             tradedAmountToken0 = buyAmount;
         }
 


### PR DESCRIPTION
Closes #91.

We update the helper to use the math proposed in #91 to compute the buy amount.
As CoW AMMs are deprecated anyway, only the helper interface matters for computing order prices.

Note that the changes are untested until #92 is merged.

If there is interest for it, the helper will be redeployed.