### PR TITLE
fix: simplified imports and rm unused variable

### DIFF
--- a/src/libraries/GetTradeableOrder.sol
+++ b/src/libraries/GetTradeableOrder.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.24;
 
 import {Math} from "lib/openzeppelin/contracts/utils/math/Math.sol";
-import {IConditionalOrder, GPv2Order, IERC20} from "lib/composable-cow/src/BaseConditionalOrder.sol";
+import {GPv2Order, IERC20} from "cowprotocol/contracts/libraries/GPv2Order.sol";
 
 library GetTradeableOrder {
     /// @dev Avoid stack too deep errors with `getTradeableOrder`.
@@ -53,19 +53,16 @@ library GetTradeableOrder {
         // isn't the AMM best price.
         uint256 selfReserve0TimesPriceDenominator = selfReserve0 * params.priceDenominator;
         uint256 selfReserve1TimesPriceNumerator = selfReserve1 * params.priceNumerator;
-        uint256 tradedAmountToken0;
         if (selfReserve1TimesPriceNumerator < selfReserve0TimesPriceDenominator) {
             sellToken = params.token0;
             buyToken = params.token1;
             sellAmount = selfReserve0 / 2 - Math.ceilDiv(selfReserve1TimesPriceNumerator, 2 * params.priceDenominator);
             buyAmount = Math.mulDiv(sellAmount, selfReserve1, selfReserve0 - sellAmount, Math.Rounding.Up);
-            tradedAmountToken0 = sellAmount;
         } else {
             sellToken = params.token1;
             buyToken = params.token0;
             sellAmount = selfReserve1 / 2 - Math.ceilDiv(selfReserve0TimesPriceDenominator, 2 * params.priceNumerator);
             buyAmount = Math.mulDiv(sellAmount, selfReserve0, selfReserve1 - sellAmount, Math.Rounding.Up);
-            tradedAmountToken0 = buyAmount;
         }
 
         order_ = GPv2Order.Data(


### PR DESCRIPTION
This PR aims to make the `GetTradeableOrder` library easily inherited by other repos.
Also it removes the unused `tradedAmountToken0` from the library.

Pending issues addressed in [draft] #98:
- [ ] installed OpenZeppelin is 4.9.0, Math Rounding enum are different than 5.0.2 ([latest](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/05f218fb6617932e56bf5388c3b389c3028a7b73/contracts/utils/math/Math.sol#L13))
- [ ] OZ 5.0.2 deprecated `safeApprove` (which brings tests errors on the "when approve returns false" expectations)